### PR TITLE
Moves all alloca to the beginning of a function.

### DIFF
--- a/src/c-compiler/genllvm/genlalloc.c
+++ b/src/c-compiler/genllvm/genlalloc.c
@@ -27,6 +27,15 @@
 LLVMValueRef genlmallocval = NULL;
 LLVMValueRef genlfreeval = NULL;
 
+// Insert the alloca before the allocaPoint instruction.
+LLVMValueRef genlAlloca(GenState *gen, LLVMTypeRef type, const char *name) {
+	LLVMBasicBlockRef current_block = LLVMGetInsertBlock(gen->builder);
+	LLVMPositionBuilderBefore(gen->builder, gen->allocaPoint);
+	LLVMValueRef alloca = LLVMBuildAlloca(gen->builder, type, name);
+	LLVMPositionBuilderAtEnd(gen->builder, current_block);
+	return alloca;
+}
+
 // Call malloc() (and generate declaration if needed)
 LLVMValueRef genlmalloc(GenState *gen, long long size) {
     // Declare malloc() external function

--- a/src/c-compiler/genllvm/genlexpr.c
+++ b/src/c-compiler/genllvm/genlexpr.c
@@ -441,7 +441,7 @@ LLVMValueRef genlConvert(GenState *gen, INode* exp, INode* to) {
     default:
         if (totype->tag == StructTag) {
             // LLVM does not bitcast structs, so this store/load hack gets around that problem
-            LLVMValueRef tempspaceptr = LLVMBuildAlloca(gen->builder, genlType(gen, fromtype), "");
+            LLVMValueRef tempspaceptr = genlAlloca(gen, genlType(gen, fromtype), "");
             LLVMValueRef store = LLVMBuildStore(gen->builder, genexp, tempspaceptr);
             LLVMValueRef castptr = LLVMBuildBitCast(gen->builder, tempspaceptr, LLVMPointerType(genlType(gen, totype),0), "");
             return LLVMBuildLoad(gen->builder, castptr, "");
@@ -456,7 +456,7 @@ LLVMValueRef genlReinterpret(GenState *gen, INode* exp, INode* to) {
     LLVMValueRef genexp = genlExpr(gen, exp);
     if (totype->tag == StructTag) {
         // LLVM does not bitcast structs, so this store/load hack gets around that problem
-        LLVMValueRef tempspaceptr = LLVMBuildAlloca(gen->builder, genlType(gen, ((IExpNode*)exp)->vtype), "");
+        LLVMValueRef tempspaceptr = genlAlloca(gen, genlType(gen, ((IExpNode*)exp)->vtype), "");
         LLVMValueRef store = LLVMBuildStore(gen->builder, genexp, tempspaceptr);
         LLVMValueRef castptr = LLVMBuildBitCast(gen->builder, tempspaceptr, LLVMPointerType(genlType(gen, totype), 0), "");
         return LLVMBuildLoad(gen->builder, castptr, "");
@@ -502,7 +502,7 @@ LLVMValueRef genlLogic(GenState *gen, LogicNode* node) {
 LLVMValueRef genlLocalVar(GenState *gen, VarDclNode *var) {
     assert(var->tag == VarDclTag);
     LLVMValueRef val = NULL;
-    var->llvmvar = LLVMBuildAlloca(gen->builder, genlType(gen, var->vtype), &var->namesym->namestr);
+    var->llvmvar = genlAlloca(gen, genlType(gen, var->vtype), &var->namesym->namestr);
     if (var->value) {
         val = genlExpr(gen, var->value);
         LLVMBuildStore(gen->builder, val, var->llvmvar);

--- a/src/c-compiler/genllvm/genllvm.h
+++ b/src/c-compiler/genllvm/genllvm.h
@@ -32,6 +32,7 @@ typedef struct GenState {
     LLVMContextRef context;
     LLVMModuleRef module;
     LLVMValueRef fn;
+    LLVMValueRef allocaPoint;
     LLVMBuilderRef builder;
     LLVMBasicBlockRef block;
 
@@ -69,6 +70,8 @@ void genlDealiasNodes(GenState *gen, Nodes *nodes);
 void genlRcCounter(GenState *gen, LLVMValueRef ref, long long amount, RefNode *refnode);
 // Dealias an own allocated reference
 void genlDealiasOwn(GenState *gen, LLVMValueRef ref, RefNode *refnode);
+// Create an alloca (will be pushed to the entry point of the function.
+LLVMValueRef genlAlloca(GenState *gen, LLVMTypeRef type, const char *name);
 
 // genltype.c
 // Generate a type value


### PR DESCRIPTION
Uses Clang's trick of an alloca instruction as an anchor for inserting allocas. Pretty much untested, so please try it out before accepting the pull req. Also, checking if compile times changes would be interesting.