### PR TITLE
Eliminate most of old aliasing logic for &rc

### DIFF
--- a/src/c-compiler/ir/exp/assign.c
+++ b/src/c-compiler/ir/exp/assign.c
@@ -144,11 +144,13 @@ void assignSingleFlow(INode *lval, INode **rval) {
     if (lval->tag == VarNameUseTag && ((NameUseNode*)lval)->namesym == anonName) {
         // When lval = '_' and this is an own reference, we may have a problem
         // If this assignment is supposed to return a reference, it cannot
+        /*
         if (flowAliasGet(0) > 0) {
             RefNode *reftype = (RefNode *)((IExpNode*)*rval)->vtype;
             if (reftype->tag == RefTag && reftype->region == (INode*)soRegion)
                 errorMsgNode((INode*)lval, ErrorMove, "This frees reference. The reference is inaccessible for use.");
         }
+        */
         return;
     }
 
@@ -191,10 +193,7 @@ void assignParaFlow(TupleNode *lval, TupleNode *rval) {
     INode **lnodesp;
     INode **rnodesp = &nodesGet(rnodes, 0);
     uint32_t rcnt = rnodes->used;
-    int16_t aliasfocus = 0;
-    flowAliasSize(lnodes->used);
     for (nodesFor(lnodes, lcnt, lnodesp)) {
-        flowAliasFocus(aliasfocus++);
         assignSingleFlow(*lnodesp, rnodesp++);
         rcnt--;
     }

--- a/src/c-compiler/ir/exp/block.c
+++ b/src/c-compiler/ir/exp/block.c
@@ -272,7 +272,6 @@ void blockFlow(FlowState *fstate, BlockNode **blknode) {
     }
 
     // Except for last node, handle all other nodes as if they throw away returned value
-    size_t svAliasPos = flowAliasPushNew(0);
     INode **nodesp;
     uint32_t cnt;
     for (nodesFor(blk->stmts, cnt, nodesp)) {
@@ -291,9 +290,7 @@ void blockFlow(FlowState *fstate, BlockNode **blknode) {
             if (isExpNode(*nodesp))
                 flowLoadValue(fstate, nodesp);
         }
-        flowAliasReset();
     }
-    flowAliasPop(svAliasPos);
 
     // Capture any scope-ending dealiasing in block's last node
     // That last node must now be a return, break, continue or an injected "block return"
@@ -303,9 +300,7 @@ void blockFlow(FlowState *fstate, BlockNode **blknode) {
         INode **retexp = &((BreakRetNode *)*nodesp)->exp;
         int doalias = flowScopeDealias(0, &((BreakRetNode *)*nodesp)->dealias, *retexp);
         if (*retexp != unknownType && doalias) {
-            size_t svAliasPos = flowAliasPushNew(1);
             flowLoadValue(fstate, retexp);
-            flowAliasPop(svAliasPos);
         }
         break;
     }

--- a/src/c-compiler/ir/exp/fncall.c
+++ b/src/c-compiler/ir/exp/fncall.c
@@ -641,16 +641,13 @@ void fnCallTypeCheck(TypeCheckState *pstate, FnCallNode **nodep) {
 // Do data flow analysis for fncall node (only real function calls)
 void fnCallFlow(FlowState *fstate, FnCallNode **nodep) {
     // Handle function call aliasing
-    size_t svAliasPos = flowAliasPushNew(1); // Alias reference arguments
     FnCallNode *node = *nodep;
     INode **argsp;
     uint32_t cnt;
     for (nodesFor(node->args, cnt, argsp)) {
         flowLoadValue(fstate, argsp);
         flowHandleMoveOrCopy(argsp);  // Argument values are moved or copied
-        flowAliasReset();
     }
-    flowAliasPop(svAliasPos);
 }
 
 // Perform data flow analysis on array index node

--- a/src/c-compiler/ir/exp/if.c
+++ b/src/c-compiler/ir/exp/if.c
@@ -212,6 +212,5 @@ void ifFlow(FlowState *fstate, IfNode **ifnodep) {
             flowLoadValue(fstate, nodesp);
         nodesp++; cnt--;
         blockFlow(fstate, (BlockNode**)nodesp);
-        flowAliasReset();
     }
 }

--- a/src/c-compiler/ir/flow.c
+++ b/src/c-compiler/ir/flow.c
@@ -40,6 +40,7 @@ void flowHandleMove(INode *node) {
 }
 
 // If needed, inject an alias node for rc/own references
+/*
 void flowInjectAliasNode(INode **nodep, int16_t rvalcount) {
     int16_t count;
     int16_t *counts = NULL;
@@ -95,6 +96,7 @@ void flowInjectAliasNode(INode **nodep, int16_t rvalcount) {
     aliasnode->counts = counts;
     *nodep = (INode*)aliasnode;
 }
+*/
 
 // Handle when we know we are either copying or moving a value
 // (e.g., for assignment or function arguments).
@@ -102,14 +104,10 @@ void flowHandleMoveOrCopy(INode **nodep) {
     uint16_t moveflag = itypeGetTypeDcl(((IExpNode *)*nodep)->vtype)->flags & MoveType;
     if (iexpIsMove(*nodep)) {
         // Moving needs to deactivate source variable use
-        if (flowAliasGet(0) > 0) {
-            flowHandleMove(*nodep);
-        }
+        flowHandleMove(*nodep);
     }
     else {
-        // Copying an owning reference triggers the region's aliasing behavior
-        flowAliasIncr();
-        flowInjectAliasNode(nodep, 0);
+        //flowInjectAliasNode(nodep, 0);
     }
 }
 
@@ -128,7 +126,6 @@ void flowLoadValue(FlowState *fstate, INode **nodep) {
         assignFlow(fstate, (AssignNode **)nodep); break;
     case FnCallTag:
         fnCallFlow(fstate, (FnCallNode**)nodep);
-        flowInjectAliasNode(nodep, -1);
         break;
     case ArrayBorrowTag:
     case BorrowTag:
@@ -137,19 +134,14 @@ void flowLoadValue(FlowState *fstate, INode **nodep) {
     case ArrayAllocTag:
     case AllocateTag:
         allocateFlow(fstate, (RefNode **)nodep);
-        flowInjectAliasNode(nodep, -1);
         break;
     case VTupleTag:
     {
         INode **nodesp;
         uint32_t cnt;
         uint32_t index = 0;
-        flowAliasSize(((TupleNode *)*nodep)->elems->used);
         for (nodesFor(((TupleNode *)*nodep)->elems, cnt, nodesp)) {
-            // pull out specific alias counter for resolution
-            size_t svAliasPos = flowAliasPushNew(flowAliasGet(index++));
             flowLoadValue(fstate, nodesp);
-            flowAliasPop(svAliasPos);
         }
         break;
     }
@@ -266,100 +258,4 @@ int flowScopeDealias(size_t startpos, Nodes **varlist, INode *retexp) {
 // Back out of current scope
 void flowScopePop(size_t startpos) {
     gVarFlowStackPos = startpos;
-}
-
-// *********************
-// Aliasing stack for data flow analysis
-//
-// As we traverse the IR nodes, this tracks expression "aliasing" in each block.
-// Aliasing is when we copy a value. This matters with rc and own references.
-// *********************
-
-int16_t *gFlowAliasStackp = NULL;
-size_t gFlowAliasStackSz = 0;
-size_t gFlowAliasStackPos = 0;
-int16_t gFlowAliasFocusPos = 0;
-
-// Ensure enough room for alias stack
-void flowAliasRoom(size_t highpos) {
-    if (highpos >= gFlowAliasStackSz) {
-        if (gFlowAliasStackSz == 0) {
-            gFlowAliasStackSz = 1024;
-            gFlowAliasStackp = (int16_t*)memAllocBlk(gFlowAliasStackSz * sizeof(int16_t));
-            memset(gFlowAliasStackp, 0, gFlowAliasStackSz * sizeof(int16_t));
-            gFlowAliasStackPos = 0;
-        }
-        else {
-            // Double table size, copying over old data
-            int16_t *oldtable = gFlowAliasStackp;
-            int oldsize = gFlowAliasStackSz;
-            gFlowAliasStackSz <<= 1;
-            gFlowAliasStackp = (int16_t*)memAllocBlk(gFlowAliasStackSz * sizeof(int16_t));
-            memset(gFlowAliasStackp, 0, gFlowAliasStackSz * sizeof(int16_t));
-            memcpy(gFlowAliasStackp, oldtable, oldsize * sizeof(int16_t));
-        }
-    }
-}
-
-// Initialize a function's alias stack
-void flowAliasInit() {
-    flowAliasRoom(3);
-    gFlowAliasStackp[0] = 1;  // current frame's # of aliasing values
-    gFlowAliasStackp[1] = 0;  // current frame's start aliasing count
-    gFlowAliasStackp[2] = 0;  // Alias count of first value
-}
-
-// Start a new frame on alias stack
-size_t flowAliasPushNew(int16_t init) {
-    size_t svpos = gFlowAliasStackPos;
-    int16_t oldstacksz = gFlowAliasStackp[svpos];
-    flowAliasRoom(5 + oldstacksz);
-    gFlowAliasStackPos += 2 + oldstacksz;
-    gFlowAliasStackp[gFlowAliasStackPos] = 1;       // current frame's # of aliasing values
-    gFlowAliasStackp[gFlowAliasStackPos+1] = init;  // current frame's start aliasing count
-    gFlowAliasStackp[gFlowAliasStackPos + 2] = init; // First value's alias count
-    return svpos;
-}
-
-// Restore previous stack
-void flowAliasPop(size_t oldpos) {
-    gFlowAliasStackPos = oldpos;
-    gFlowAliasFocusPos = 0;
-}
-
-// Reset current frame (to one value initialized to init value)
-void flowAliasReset() {
-    gFlowAliasStackp[gFlowAliasStackPos] = 1;
-    gFlowAliasStackp[gFlowAliasStackPos + 2] = gFlowAliasStackp[gFlowAliasStackPos + 1];
-}
-
-// Ensure frame has enough initialized alias counts for 'size' values
-void flowAliasSize(int16_t size) {
-    int16_t stacksz = gFlowAliasStackp[gFlowAliasStackPos];
-    if (stacksz >= size)
-        return;
-    int16_t init = gFlowAliasStackp[gFlowAliasStackPos + 1];
-    while (stacksz < size)
-        gFlowAliasStackp[gFlowAliasStackPos + 2 + stacksz++] = init;
-    gFlowAliasStackp[gFlowAliasStackPos] = size;
-}
-
-// Set the focus position for lval aliasing
-void flowAliasFocus(int16_t pos) {
-    gFlowAliasFocusPos = pos;
-}
-
-// Increment aliasing count at frame's position
-void flowAliasIncr() {
-    ++gFlowAliasStackp[gFlowAliasStackPos + 2 + gFlowAliasFocusPos];
-}
-
-// Get aliasing count at frame's position
-int16_t flowAliasGet(size_t pos) {
-    return gFlowAliasStackp[gFlowAliasStackPos + 2 + pos];
-}
-
-// Store an aliasing count at frame's position
-void flowAliasPut(size_t pos, int16_t count) {
-    gFlowAliasStackp[gFlowAliasStackPos + 2 + pos] = count;
 }

--- a/src/c-compiler/ir/flow.h
+++ b/src/c-compiler/ir/flow.h
@@ -57,31 +57,4 @@ typedef struct {
 // Handle when moving or copying a value to a new destination
 void flowHandleMoveOrCopy(INode **nodep);
 
-// Initialize a function's alias stack
-void flowAliasInit();
-
-// Start a new frame on alias stack
-size_t flowAliasPushNew(int16_t init);
-
-// Restore previous stack
-void flowAliasPop(size_t oldpos);
-
-// Reset current frame (to one value initialized to init value)
-void flowAliasReset();
-
-// Ensure frame has enough initialized alias counts for 'size' values
-void flowAliasSize(int16_t size);
-
-// Set the focus position for lval aliasing
-void flowAliasFocus(int16_t pos);
-
-// Increment aliasing count at frame's position
-void flowAliasIncr();
-
-// Get aliasing count at frame's position
-int16_t flowAliasGet(size_t pos);
-
-// Store an aliasing count at frame's position
-void flowAliasPut(size_t pos, int16_t count);
-
 #endif

--- a/src/c-compiler/ir/stmt/fndcl.c
+++ b/src/c-compiler/ir/stmt/fndcl.c
@@ -127,7 +127,6 @@ void fnDclTypeCheck(TypeCheckState *pstate, FnDclNode *fnnode) {
     // We run data flow separately as it requires type info which is inferred bottoms-up
     if (errors)
         return;
-    flowAliasInit();
     FlowState fstate;
     fstate.fnsig = (FnSigNode *)fnnode->vtype;
     fstate.scope = 1;

--- a/src/c-compiler/ir/stmt/vardcl.c
+++ b/src/c-compiler/ir/stmt/vardcl.c
@@ -124,10 +124,8 @@ void varDclTypeCheck(TypeCheckState *pstate, VarDclNode *name) {
 void varDclFlow(FlowState *fstate, VarDclNode **vardclnode) {
     flowAddVar(*vardclnode);
     if ((*vardclnode)->value) {
-        size_t svAliasPos = flowAliasPushNew(1);
         flowLoadValue(fstate, &((*vardclnode)->value));
         flowHandleMoveOrCopy(&((*vardclnode)->value));  // initialization copies/moves value
-        flowAliasPop(svAliasPos);
         (*vardclnode)->flowtempflags |= VarInitialized;
     }
 }


### PR DESCRIPTION
We need to transition to more flexible region annotations on owning references, instead of current hard-coded regions. This clears some of the old garbage logic out of the way to smooth that transition.