### PR TITLE
Fix the ownership memory-safety defects, and settle what a reference count means

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ __pycache__/
 
 # Folders
 .vs/
+.claude/worktrees/
 build
 bin
 obj

--- a/src/c-compiler/genllvm/genlalloc.c
+++ b/src/c-compiler/genllvm/genlalloc.c
@@ -195,7 +195,10 @@ LLVMValueRef genlallocref(GenState *gen, RefNode *allocatenode) {
         tuplevalnull = LLVMBuildInsertValue(gen->builder, tuplevalnull, blkvals[0], 0, "fatptr");
         blkvals[0] = LLVMBuildInsertValue(gen->builder, tuplevalnull, LLVMConstInt(genlType(gen, (INode*)usizeType), 0, 0), 1, "fatsize");
     }
-    blks[0] = panicblk;
+    // The phi's predecessor is whatever block the builder ended up in, which is not
+    // necessarily the block we positioned it in: generating the value above may have
+    // emitted branches of its own, splitting the block it started in.
+    blks[0] = LLVMGetInsertBlock(gen->builder);
     LLVMBuildBr(gen->builder, endif);
     LLVMPositionBuilderAtEnd(gen->builder, initblk);
 
@@ -241,9 +244,11 @@ LLVMValueRef genlallocref(GenState *gen, RefNode *allocatenode) {
         valuep = LLVMBuildInsertValue(gen->builder, tupleval, nbrelems, 1, "fatsize");
     }
     blkvals[1] = valuep;
-    blks[1] = initblk;
 
-    // Finish up block, start new one, and return allocated
+    // Finish up block, start new one, and return allocated. As above, an initial value
+    // holding another allocation splits initblk, so the edge arrives from wherever the
+    // builder now is rather than from initblk.
+    blks[1] = LLVMGetInsertBlock(gen->builder);
     LLVMBuildBr(gen->builder, endif);
     LLVMPositionBuilderAtEnd(gen->builder, endif);
     LLVMValueRef phi = LLVMBuildPhi(gen->builder, reftypellvm, "allocphi");

--- a/src/c-compiler/genllvm/genlalloc.c
+++ b/src/c-compiler/genllvm/genlalloc.c
@@ -227,7 +227,7 @@ LLVMValueRef genlallocref(GenState *gen, RefNode *allocatenode) {
     }
     else {
         // Handle array fill via run-time generation
-        if (allocatenode->vtexp->tag == ArrayLitTag && ((ArrayNode*)allocatenode->vtexp)->dimens > 0) {
+        if (allocatenode->vtexp->tag == ArrayLitTag && ((ArrayNode*)allocatenode->vtexp)->dimens->used > 0) {
             genlAllocFillArray(gen, nbrelems, (ArrayNode*)allocatenode->vtexp, valuep);
         }
         else {

--- a/src/c-compiler/genllvm/genlalloc.c
+++ b/src/c-compiler/genllvm/genlalloc.c
@@ -59,7 +59,10 @@ void genlDealiasFlds(GenState *gen, LLVMValueRef ref, RefNode *refnode) {
         RefNode *vartype = (RefNode *)field->vtype;
         if (vartype->tag != RefTag || !(isRegion(vartype->region, rcName) || isRegion(vartype->region, soName)))
             continue;
-        LLVMValueRef fldref = LLVMBuildStructGEP(gen->builder, ref, field->index, &field->namesym->namestr);
+        // The GEP yields the field's address; the release routines want the
+        // reference the field holds, so load it.
+        LLVMValueRef fldptr = LLVMBuildStructGEP(gen->builder, ref, field->index, &field->namesym->namestr);
+        LLVMValueRef fldref = LLVMBuildLoad(gen->builder, fldptr, "fldref");
         if (isRegion(vartype->region, soName))
             genlDealiasOwn(gen, fldref, vartype);
         else

--- a/src/c-compiler/genllvm/genlexpr.c
+++ b/src/c-compiler/genllvm/genlexpr.c
@@ -863,7 +863,26 @@ LLVMValueRef genlExpr(GenState *gen, INode *termnode) {
                 *valuep++ = genlExpr(gen, *nodesp);
         }
         INode *elemtype = nodesGet(((ArrayNode *)itypeGetTypeDcl(lit->vtype))->elems, 0);
-        return LLVMConstArray(genlType(gen, elemtype), values, size);
+        LLVMTypeRef elemtypellvm = genlType(gen, elemtype);
+        // A constant aggregate's operands must themselves be constants, so an element
+        // that is the result of an instruction -- a variable read, a call, an
+        // allocation -- cannot go into LLVMConstArray. Build the array up with
+        // insertvalue in that case, as a struct literal does. The constant array is
+        // kept where every element qualifies: it is cheaper, and it is the only form
+        // usable outside a function body.
+        int allconst = 1;
+        for (uint32_t index = 0; index < size; ++index) {
+            if (!LLVMIsConstant(values[index])) {
+                allconst = 0;
+                break;
+            }
+        }
+        if (allconst)
+            return LLVMConstArray(elemtypellvm, values, size);
+        LLVMValueRef arrayval = LLVMGetUndef(LLVMArrayType(elemtypellvm, size));
+        for (uint32_t index = 0; index < size; ++index)
+            arrayval = LLVMBuildInsertValue(gen->builder, arrayval, values[index], index, "arraylit");
+        return arrayval;
     }
     case TypeLitTag:
     {

--- a/src/c-compiler/genllvm/genlexpr.c
+++ b/src/c-compiler/genllvm/genlexpr.c
@@ -815,7 +815,8 @@ void genlStore(GenState *gen, INode *lval, LLVMValueRef rval) {
         return;
     LLVMValueRef lvalptr = genlAddr(gen, lval);
     RefNode *reftype = (RefNode *)((IExpNode*)lval)->vtype;
-    if (reftype->tag == RefTag && isRegion(reftype->region, rcName))
+    // A first assignment has no previous value to release (see FlagFirstAssign)
+    if (reftype->tag == RefTag && isRegion(reftype->region, rcName) && !(lval->flags & FlagFirstAssign))
         genlRcCounter(gen, LLVMBuildLoad(gen->builder, lvalptr, "dealiasref"), -1, reftype);
     LLVMBuildStore(gen->builder, rval, lvalptr);
 }

--- a/src/c-compiler/ir/exp/arraylit.c
+++ b/src/c-compiler/ir/exp/arraylit.c
@@ -126,9 +126,12 @@ static int64_t arrayLitFillCount(ArrayNode *arrlit) {
 //   amount is a constant in the alias node, so a count known only at run time
 //   cannot be expressed and is refused rather than counted wrongly.
 //
-// Both refusals are the same condition, that a fill cannot repeat this value.
-// The general answer -- rewriting a fill into a loop that builds the elements one
-// at a time, before generation -- is recorded in the Types. Array work item.
+// The refusals carry two codes because they have two lifetimes. ErrorBadFill is a
+// language rule -- a move value has one owner, so it may not be repeated -- and
+// outlives this implementation. ErrorFillCount says only that the count cannot be
+// carried by a constant alias amount, and should disappear when a fill is rewritten
+// into a loop that builds the elements one at a time, before generation. That
+// general answer is recorded in the Types. Array work item.
 void arrayLitFlow(FlowState *fstate, ArrayNode **nodep) {
     ArrayNode *arrlit = *nodep;
     INode **elemsp;
@@ -157,12 +160,12 @@ void arrayLitFlow(FlowState *fstate, ArrayNode **nodep) {
 
     int64_t nbrelems = arrayLitFillCount(arrlit);
     if (nbrelems < 0) {
-        errorMsgNode(*valp, ErrorBadFill,
+        errorMsgNode(*valp, ErrorFillCount,
             "An array fill literal whose value is a counted reference needs an element count known at compile time.");
         return;
     }
     if (nbrelems > INT16_MAX) {
-        errorMsgNode(*valp, ErrorBadFill,
+        errorMsgNode(*valp, ErrorFillCount,
             "An array fill literal has too many elements to count a reference into.");
         return;
     }

--- a/src/c-compiler/ir/exp/arraylit.c
+++ b/src/c-compiler/ir/exp/arraylit.c
@@ -7,6 +7,8 @@
 
 #include "../ir.h"
 
+#include <limits.h>
+
 // Note:  Creation, serialization and name checking are done with array type logic,
 // as we don't yet know whether [] is a type or an array literal
 
@@ -87,6 +89,86 @@ void arrayLitTypeCheck(TypeCheckState *pstate, ArrayNode *arrlit) {
         errorMsgNode((INode*)arrlit, ErrorBadArray, "Array literal dimension value must be a constant");
     }
     arrayLitTypeCheckDimExp(pstate, arrlit);
+}
+
+// Return a fill literal's element count, or -1 when it is not known until run time.
+// The dimension may be a named constant, which code generation resolves the same way.
+// A count past what an alias amount can hold is clamped to just past it, so the
+// caller refuses it rather than wrapping into a plausible-looking number.
+static int64_t arrayLitFillCount(ArrayNode *arrlit) {
+    INode *dimnode = nodesGet(arrlit->dimens, 0);
+    while (dimnode->tag == VarNameUseTag) {
+        INode *dclnode = ((NameUseNode*)dimnode)->dclnode;
+        if (dclnode->tag != ConstDclTag)
+            return -1;
+        dimnode = ((ConstDclNode*)dclnode)->value;
+    }
+    if (dimnode->tag != ULitTag)
+        return -1;
+    uint64_t nbrelems = ((ULitNode*)dimnode)->uintlit;
+    return nbrelems > (uint64_t)INT16_MAX ? (int64_t)INT16_MAX + 1 : (int64_t)nbrelems;
+}
+
+// Perform data flow analysis on an array literal's element values.
+//
+// The list form '[a, b]' gives every element a holder of its own, so each value
+// is moved or copied exactly as a function call's argument is.
+//
+// The fill form '[n; value]' evaluates one expression and stores it into every
+// element, which the two ownership rules answer differently:
+//
+// - A move value has exactly one owner and cannot have n of them, so filling
+//   with one is refused however small n is. Proving n is 1 would buy a construct
+//   nobody writes at the cost of a rule that is harder to state.
+// - A counted reference may legitimately be repeated, but n holders appear
+//   rather than one, so the count rises by n -- or by n-1 when the value is a
+//   temporary, which hands over the one reference it was born holding. That
+//   amount is a constant in the alias node, so a count known only at run time
+//   cannot be expressed and is refused rather than counted wrongly.
+//
+// Both refusals are the same condition, that a fill cannot repeat this value.
+// The general answer -- rewriting a fill into a loop that builds the elements one
+// at a time, before generation -- is recorded in the Types. Array work item.
+void arrayLitFlow(FlowState *fstate, ArrayNode **nodep) {
+    ArrayNode *arrlit = *nodep;
+    INode **elemsp;
+    uint32_t cnt;
+
+    // List form: each element is its own holder
+    if (arrlit->dimens->used == 0) {
+        for (nodesFor(arrlit->elems, cnt, elemsp)) {
+            flowLoadValue(fstate, elemsp);
+            flowHandleMoveOrCopy(elemsp);
+        }
+        return;
+    }
+
+    // Fill form: one value, repeated
+    INode **valp = &nodesGet(arrlit->elems, 0);
+    flowLoadValue(fstate, valp);
+    if (iexpIsMove(*valp)) {
+        errorMsgNode(*valp, ErrorBadFill,
+            "An array fill literal may not repeat a move value, which may have only one owner.");
+        return;
+    }
+    RefNode *reftype = (RefNode *)iexpGetTypeDcl(*valp);
+    if (reftype->tag != RefTag || !isRegion(reftype->region, rcName))
+        return;   // Any other value copies freely, needing no count
+
+    int64_t nbrelems = arrayLitFillCount(arrlit);
+    if (nbrelems < 0) {
+        errorMsgNode(*valp, ErrorBadFill,
+            "An array fill literal whose value is a counted reference needs an element count known at compile time.");
+        return;
+    }
+    if (nbrelems > INT16_MAX) {
+        errorMsgNode(*valp, ErrorBadFill,
+            "An array fill literal has too many elements to count a reference into.");
+        return;
+    }
+    int16_t amt = flowIsLvalRead(*valp) ? (int16_t)nbrelems : (int16_t)(nbrelems - 1);
+    if (amt != 0)
+        flowInjectAliasAmt(valp, amt);
 }
 
 // Is the array actually a literal?

--- a/src/c-compiler/ir/exp/arraylit.h
+++ b/src/c-compiler/ir/exp/arraylit.h
@@ -14,6 +14,9 @@ void arrayLitTypeCheckDimExp(TypeCheckState *pstate, ArrayNode *arrlit);
 // Type check an array literal
 void arrayLitTypeCheck(TypeCheckState *pstate, ArrayNode *arrlit);
 
+// Perform data flow analysis on an array literal's element values
+void arrayLitFlow(FlowState *fstate, ArrayNode **nodep);
+
 // Is an array actually a literal?
 int arrayLitIsLiteral(ArrayNode *node);
 

--- a/src/c-compiler/ir/exp/assign.c
+++ b/src/c-compiler/ir/exp/assign.c
@@ -166,6 +166,11 @@ int assignlvalrtype(INode *lval, INode *rtype) {
 
     // Mark that lval variable has valid initialized value.
     if (lval->tag == VarNameUseTag) {
+        // Stopgap: record on this use that the variable held nothing yet, so code
+        // generation does not release uninitialized storage. Flow state is a
+        // running summary, so only the assignment site itself can carry this.
+        if (!(((VarDclNode*)lvalvar)->flowtempflags & VarInitialized))
+            lval->flags |= FlagFirstAssign;
         ((VarDclNode*)lvalvar)->flowtempflags |= VarInitialized;
         ((VarDclNode*)lvalvar)->flowtempflags &= 0xFFFF - VarMoved;
     }

--- a/src/c-compiler/ir/exp/cast.c
+++ b/src/c-compiler/ir/exp/cast.c
@@ -172,8 +172,10 @@ void castIsTypeCheck(TypeCheckState *pstate, CastNode *node) {
         RefNode *from = (RefNode*)fromtype;
         RefNode *to = (RefNode*)totype;
 
-        // Match on region & permission
-        TypeCompare result = regionMatches(from->region, to->region, Coercion);
+        // Regions must match. A downcast may not move a reference from one region
+        // to another: they are represented differently in memory, so there is no
+        // recast between them, not even into a borrow.
+        TypeCompare result = itypeIsSame(from->region, to->region) ? EqMatch : NoMatch;
         if (result != NoMatch)
             result = permMatches(to->perm, from->perm);
         if (result == NoMatch) {

--- a/src/c-compiler/ir/exp/typelit.c
+++ b/src/c-compiler/ir/exp/typelit.c
@@ -155,6 +155,21 @@ void typeLitStructCheck(TypeCheckState *pstate, FnCallNode *arrlit, StructNode *
 
 // Check the list node
 // Note:  We get here from FnCallTypeCheck, which has already checked that all arguments are expressions
+// Perform data flow analysis on a type literal's field values.
+// A literal initializes its fields from expressions, so each value is moved or
+// copied exactly as a function call's argument is. A value given by field name
+// is wrapped in a NamedValNode, which is unwrapped here so the decision is made
+// about the value itself.
+void typeLitFlow(FlowState *fstate, FnCallNode **nodep) {
+    INode **argsp;
+    uint32_t cnt;
+    for (nodesFor((*nodep)->args, cnt, argsp)) {
+        INode **valp = (*argsp)->tag == NamedValTag ? &((NamedValNode *)*argsp)->val : argsp;
+        flowLoadValue(fstate, valp);
+        flowHandleMoveOrCopy(valp);
+    }
+}
+
 void typeLitTypeCheck(TypeCheckState *pstate, FnCallNode *arrlit) {
 
     INode *littype = itypeGetTypeDcl(arrlit->vtype);

--- a/src/c-compiler/ir/exp/typelit.h
+++ b/src/c-compiler/ir/exp/typelit.h
@@ -24,4 +24,7 @@ void typeLitTypeCheck(TypeCheckState *pstate, FnCallNode *lit);
 // Is the type literal actually a literal?
 int typeLitIsLiteral(FnCallNode *node);
 
+// Perform data flow analysis on a type literal's field values
+void typeLitFlow(FlowState *fstate, FnCallNode **nodep);
+
 #endif

--- a/src/c-compiler/ir/flow.c
+++ b/src/c-compiler/ir/flow.c
@@ -203,6 +203,14 @@ int flowScopeDealias(size_t startpos, Nodes **varlist, INode *retexp) {
         INode *vartype = avar->node->vtype;
         RefNode *reftype = (RefNode*)vartype;
         if (reftype->tag == RefTag && (isRegion(reftype->region, soName) || isRegion(reftype->region, rcName))) {
+            // Stopgap: a variable whose value was moved out no longer owns it, so
+            // releasing it here would free the new owner's allocation a second
+            // time. VarMoved is the state at scope exit rather than at each
+            // program point, so a value moved on only one branch is skipped on
+            // all of them -- that leaks rather than double-frees. Precise
+            // deactivation belongs to the region redesign.
+            if (avar->node->flowtempflags & VarMoved)
+                continue;
             if (retexp && (retexp->tag != VarNameUseTag || ((NameUseNode *)retexp)->namesym != avar->node->namesym)) {
                 if (*varlist == NULL)
                     *varlist = newNodes(4);

--- a/src/c-compiler/ir/flow.c
+++ b/src/c-compiler/ir/flow.c
@@ -59,14 +59,33 @@ void flowInjectAliasNode(INode **nodep) {
 
 // Handle when we know we are either copying or moving a value
 // (e.g., for assignment or function arguments).
+// Does this expression still hold its value after it is read?
+// An lvalue names storage that keeps it; anything else is a temporary.
+int flowIsLvalRead(INode *node) {
+    switch (node->tag) {
+    case VarNameUseTag:
+    case DerefTag:
+    case ArrIndexTag:
+    case FldAccessTag:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 void flowHandleMoveOrCopy(INode **nodep) {
-    uint16_t moveflag = itypeGetTypeDcl(((IExpNode *)*nodep)->vtype)->flags & MoveType;
     if (iexpIsMove(*nodep)) {
         // Moving needs to deactivate source variable use
         flowHandleMove(*nodep);
     }
     else {
-        flowInjectAliasNode(nodep);
+        // A reference count is how many holders exist. Only an lvalue still
+        // holds its reference afterwards, so only an lvalue adds a holder. A
+        // temporary -- an allocation, a call's result, a literal -- hands over
+        // the reference it was born holding, and counting that again would
+        // count one holder twice.
+        if (flowIsLvalRead(*nodep))
+            flowInjectAliasNode(nodep);
     }
 }
 
@@ -130,12 +149,15 @@ void flowLoadValue(FlowState *fstate, INode **nodep) {
         break;
     }
 
+    case TypeLitTag:
+        typeLitFlow(fstate, (FnCallNode**)nodep);
+        break;
+
     case SizeofTag:
     case NilLitTag:
     case ULitTag:
     case FLitTag:
     case StringLitTag:
-    case TypeLitTag:
     case ArrayLitTag:
     case AbsenceTag:
     case UnknownTag:

--- a/src/c-compiler/ir/flow.c
+++ b/src/c-compiler/ir/flow.c
@@ -39,8 +39,10 @@ void flowHandleMove(INode *node) {
     }
 }
 
-// If needed, inject an alias node for rc/own references
-void flowInjectAliasNode(INode **nodep) {
+// If needed, inject an alias node for rc/own references, adjusting the count by amt.
+// One value can become more than one holder at once: an array fill literal stores
+// the reference it evaluates once into every one of its elements.
+void flowInjectAliasAmt(INode **nodep, int16_t amt) {
     INode *vtype = ((IExpNode*)*nodep)->vtype;
     // No need for injected node if we are not dealing with rc references
     RefNode *reftype = (RefNode *)itypeGetTypeDcl(vtype);
@@ -52,9 +54,14 @@ void flowInjectAliasNode(INode **nodep) {
     newNode(aliasnode, AliasNode, AliasTag);
     aliasnode->exp = *nodep;
     aliasnode->vtype = vtype;
-    aliasnode->aliasamt = 1;
+    aliasnode->aliasamt = amt;
     aliasnode->counts = NULL;
     *nodep = (INode*)aliasnode;
+}
+
+// If needed, inject an alias node for rc/own references
+void flowInjectAliasNode(INode **nodep) {
+    flowInjectAliasAmt(nodep, 1);
 }
 
 // Handle when we know we are either copying or moving a value
@@ -153,12 +160,15 @@ void flowLoadValue(FlowState *fstate, INode **nodep) {
         typeLitFlow(fstate, (FnCallNode**)nodep);
         break;
 
+    case ArrayLitTag:
+        arrayLitFlow(fstate, (ArrayNode**)nodep);
+        break;
+
     case SizeofTag:
     case NilLitTag:
     case ULitTag:
     case FLitTag:
     case StringLitTag:
-    case ArrayLitTag:
     case AbsenceTag:
     case UnknownTag:
         break;

--- a/src/c-compiler/ir/flow.h
+++ b/src/c-compiler/ir/flow.h
@@ -57,4 +57,10 @@ typedef struct {
 // Handle when moving or copying a value to a new destination
 void flowHandleMoveOrCopy(INode **nodep);
 
+// Does this expression still hold its value after it is read?
+int flowIsLvalRead(INode *node);
+
+// If needed, inject an alias node for rc references, adjusting the count by amt
+void flowInjectAliasAmt(INode **nodep, int16_t amt);
+
 #endif

--- a/src/c-compiler/ir/inode.h
+++ b/src/c-compiler/ir/inode.h
@@ -193,6 +193,8 @@ enum NodeTags {
 
 #define FlagUnkType   0x0001        // ULit: type is unspecified and may be converted to other number
 
+#define FlagFirstAssign 0x0080      // VarNameUse: assignment target held no prior value
+
 // Flags used across all types
 #define MoveType           0x0001  // Type's values impose move semantics (vs. copy)
 #define ThreadBound        0x0002  // Type's value copies must stay in the same thread (vs. sendable)

--- a/src/c-compiler/ir/types/arrayref.c
+++ b/src/c-compiler/ir/types/arrayref.c
@@ -79,7 +79,7 @@ TypeCompare arrayRefMatchesRef(RefNode *to, RefNode *from, SubtypeConstraint con
         return NoMatch;
 
     // Start with matching the references' regions
-    if (regionMatches(from->region, to->region, constraint) == NoMatch)
+    if (regionMatches(to->region, from->region, constraint) == NoMatch)
         return NoMatch;
 
     // Now their permissions

--- a/src/c-compiler/ir/types/reference.c
+++ b/src/c-compiler/ir/types/reference.c
@@ -178,7 +178,7 @@ TypeCompare regionMatches(INode *to, INode *from, SubtypeConstraint constraint) 
 TypeCompare refMatches(RefNode *to, RefNode *from, SubtypeConstraint constraint) {
 
     // Start with matching the references' regions
-    TypeCompare result = regionMatches(from->region, to->region, constraint);
+    TypeCompare result = regionMatches(to->region, from->region, constraint);
     if (result == NoMatch)
         return NoMatch;
 
@@ -223,7 +223,7 @@ TypeCompare refvirtMatchesRef(RefNode *to, RefNode *from, SubtypeConstraint cons
         return NoMatch;
 
     // Start with matching the references' regions
-    TypeCompare result = regionMatches(from->region, to->region, constraint);
+    TypeCompare result = regionMatches(to->region, from->region, constraint);
     if (result == NoMatch)
         return NoMatch;
 

--- a/src/c-compiler/shared/error.h
+++ b/src/c-compiler/shared/error.h
@@ -92,6 +92,7 @@ enum ErrorCode {
 
     // Array literals
     ErrorBadFill = 1059,        // Array fill literal may not repeat this value
+    ErrorFillCount = 1060,      // Array fill literal's element count cannot be counted into
 
     // Warnings
     WarnCode = 3000,

--- a/src/c-compiler/shared/error.h
+++ b/src/c-compiler/shared/error.h
@@ -90,6 +90,9 @@ enum ErrorCode {
     ErrorAmbigCandidate = 1057, // More than one overloaded candidate accepts the call's arguments
     ErrorOverloadUse = 1058,    // Overload name used somewhere other than a call's callee
 
+    // Array literals
+    ErrorBadFill = 1059,        // Array fill literal may not repeat this value
+
     // Warnings
     WarnCode = 3000,
     WarnName = 3001,        // Unnecessary name

--- a/test/cases/array/array-nonconst-literal.cone
+++ b/test/cases/array/array-nonconst-literal.cone
@@ -1,21 +1,86 @@
-// Defect: an array literal whose elements are not compile-time constants
-// generates invalid LLVM IR, and the module fails verification.
+// An array literal whose elements are computed rather than constant: both
+// literal forms, and an element type that is a struct as well as a number.
 //
-// genlExpr builds both literal forms with LLVMConstArray, which takes constants.
-// Handed the result of an instruction instead -- the load of a variable, of a
-// parameter, of anything computed -- it produces a constant array whose operands
-// are instructions, and the verifier reports "Use of instruction is not an
-// instruction!". Both forms are affected and the element type is irrelevant:
-// array-success only ever writes literal elements, which is why the group did
-// not see this.
+// A constant aggregate's operands must themselves be constants, so an element
+// that is the result of an instruction -- a variable read, arithmetic, a call --
+// cannot go into the constant array both forms were once built with. genlExpr
+// keeps that form only when every element qualifies and otherwise builds the
+// array up with insertvalue, which is what a struct literal has always done.
 //
-// It is the reason no fill literal holding a counted reference can be asserted
-// against generated code; region-fill-count records that consequence.
+// Everything is printed, because an array that survives verification is not an
+// array whose elements arrived: an insertvalue chain that indexed wrongly, or
+// dropped an element, would still generate and still verify. The values are
+// derived from a parameter so that nothing here can fold to a constant, and the
+// all-constant literal is kept alongside them to hold the cheaper form down.
 
-fn nonconstFill(n i32) {
-  imm a = [3; n]
+import stdio::*
+
+fn show(label &[]u8, n i64) {
+  printStr(label)
+  printStr(" = ")
+  printInt(n)
+  printStr("\n")
 }
 
-fn nonconstList(n i32) {
-  imm a = [n, n]
+struct Point {
+  mut x i32
+  mut y i32
+}
+
+fn twice(n i32) i32 {
+  n + n
+}
+
+// -------- the fill form --------
+
+fn fillFromComputed(n i32) {
+  // One computed value repeated: every element must be that value
+  imm a = [3; twice(n)]
+  show("fill-first", a[0])
+  show("fill-middle", a[1])
+  show("fill-last", a[2])
+}
+
+// -------- the list form --------
+
+fn listFromComputed(n i32) {
+  // Each element a different instruction, so a chain that mixed up its indices
+  // would show up as the wrong number rather than as a verifier complaint
+  imm a = [n, n + 1, twice(n), n - 1]
+  show("list-0", a[0])
+  show("list-1", a[1])
+  show("list-2", a[2])
+  show("list-3", a[3])
+}
+
+// -------- element type is irrelevant --------
+
+fn structElems(n i32) {
+  imm a = [2; Point[n, twice(n)]]
+  show("struct-fill-x", a[1].x)
+  show("struct-fill-y", a[1].y)
+
+  imm b = [Point[n, 1], Point[2, n]]
+  show("struct-list-x", b[0].x)
+  show("struct-list-y", b[1].y)
+}
+
+// -------- the constant form still works --------
+
+fn constantsUnchanged() {
+  // Every element a constant, which is the form that was always generated
+  imm a = [11, 22, 33]
+  show("const-first", a[0])
+  show("const-last", a[2])
+
+  imm b = [3; 44]
+  show("const-fill", b[1])
+}
+
+fn main() i32 {
+  fillFromComputed(5i32)
+  listFromComputed(10i32)
+  structElems(3i32)
+  constantsUnchanged()
+  0i32
 }

--- a/test/cases/array/array-nonconst-literal.cone
+++ b/test/cases/array/array-nonconst-literal.cone
@@ -1,0 +1,21 @@
+// Defect: an array literal whose elements are not compile-time constants
+// generates invalid LLVM IR, and the module fails verification.
+//
+// genlExpr builds both literal forms with LLVMConstArray, which takes constants.
+// Handed the result of an instruction instead -- the load of a variable, of a
+// parameter, of anything computed -- it produces a constant array whose operands
+// are instructions, and the verifier reports "Use of instruction is not an
+// instruction!". Both forms are affected and the element type is irrelevant:
+// array-success only ever writes literal elements, which is why the group did
+// not see this.
+//
+// It is the reason no fill literal holding a counted reference can be asserted
+// against generated code; region-fill-count records that consequence.
+
+fn nonconstFill(n i32) {
+  imm a = [3; n]
+}
+
+fn nonconstList(n i32) {
+  imm a = [n, n]
+}

--- a/test/cases/array/array-nonconst-literal.out
+++ b/test/cases/array/array-nonconst-literal.out
@@ -1,0 +1,14 @@
+fill-first = 10
+fill-middle = 10
+fill-last = 10
+list-0 = 10
+list-1 = 11
+list-2 = 20
+list-3 = 9
+struct-fill-x = 3
+struct-fill-y = 6
+struct-list-x = 3
+struct-list-y = 3
+const-first = 11
+const-last = 33
+const-fill = 44

--- a/test/cases/array/array-success.cone
+++ b/test/cases/array/array-success.cone
@@ -8,6 +8,10 @@
 // only to establish that an array can be a member. The array is the whole
 // subject, so it is exercised in every position a value can occupy: local,
 // global, member, parameter, return value and element of another array.
+//
+// Every literal here has constant elements, which is what a literal form means
+// at the source level but not all a literal can hold. A literal whose elements
+// are computed is generated differently, and array-nonconst-literal owns it.
 
 import stdio::*
 

--- a/test/cases/array/cases.toml
+++ b/test/cases/array/cases.toml
@@ -8,6 +8,13 @@
 # collection's subject, not this group's, so they appear here only as the
 # '&[]u8' string parameter every run scenario's print helpers need.
 #
+# The two success scenarios split on whether a literal's elements are constants.
+# array-success writes only constant ones, which is the whole of what the two
+# literal forms mean at the source level; array-nonconst-literal writes computed
+# ones, which is a code generation question, because a constant array cannot hold
+# the result of an instruction and the group did not notice until a counted
+# reference had to be filled into one.
+#
 # Both reject scenarios are type-check stage; the array syntax gives the parser
 # nothing of its own to reject, and an array's names resolve like any other
 # type's. They are split by sub-family rather than by stage: array-reject-shape
@@ -46,6 +53,20 @@ category = "run"
 description = "Array types, literals, indexing, element assignment and copy semantics"
 tags = ["parse", "nameres", "typecheck", "flow", "genllvm", "runtime"]
 
+# Separate from array-success because it is the scenario a code generation fix
+# landed with: both literal forms were built with LLVMConstArray, so an element
+# that was the result of an instruction rather than a constant produced a
+# constant array with instruction operands and the module failed verification.
+# array-success writes only constant elements, which is why the group did not
+# record this until a counted reference needed to be filled into one. A 'run'
+# rather than a 'compile': surviving verification is the smaller half of the
+# claim, and only printing the elements shows that an insertvalue chain put each
+# one where it belongs.
+[scenario.array-nonconst-literal]
+category = "run"
+description = "An array literal whose elements are computed rather than constant, in both forms and for a struct element type"
+tags = ["genllvm", "runtime"]
+
 # -------- type check stage --------
 
 [scenario.array-reject-shape]
@@ -59,16 +80,3 @@ category = "reject"
 description = "Array initializers, indices and member access the compiler rejects"
 tags = ["typecheck"]
 diagnostics = 5
-
-# -------- known defects --------
-
-# Both literal forms are built with LLVMConstArray, so an element that is the
-# result of an instruction rather than a constant produces a constant array with
-# instruction operands, which the module verifier rejects. array-success writes
-# only literal elements, which is why the group did not record this until a
-# counted reference needed to be filled into one.
-[scenario.array-nonconst-literal]
-category = "compile"
-description = "An array literal whose elements are computed rather than constant"
-tags = ["genllvm"]
-xfail = true

--- a/test/cases/array/cases.toml
+++ b/test/cases/array/cases.toml
@@ -59,3 +59,16 @@ category = "reject"
 description = "Array initializers, indices and member access the compiler rejects"
 tags = ["typecheck"]
 diagnostics = 5
+
+# -------- known defects --------
+
+# Both literal forms are built with LLVMConstArray, so an element that is the
+# result of an instruction rather than a constant produces a constant array with
+# instruction operands, which the module verifier rejects. array-success writes
+# only literal elements, which is why the group did not record this until a
+# counted reference needed to be filled into one.
+[scenario.array-nonconst-literal]
+category = "compile"
+description = "An array literal whose elements are computed rather than constant"
+tags = ["genllvm"]
+xfail = true

--- a/test/cases/collection/collection-success.cone
+++ b/test/cases/collection/collection-success.cone
@@ -203,6 +203,20 @@ fn members() {
   show("write-through-member-slice", b[2])
 }
 
+// A slice's other origin: allocated rather than borrowed. Every element of the
+// literal reaches its own slot, which is the whole of what this asserts --
+// genlallocref tested the literal's 'dimens' pointer rather than its count, so
+// every allocation took the fill path and stored the first element into all of
+// them. A length that is right and elements that are wrong is exactly the shape
+// this group already refuses to accept from a borrowed slice.
+fn allocated() {
+  imm owned = +[]rc-mut [11i32, 22i32, 33i32]
+  showU("allocated-slice-len", owned.len)
+  show("allocated-first", owned[0])
+  show("allocated-middle", owned[1])
+  show("allocated-last", owned[2])
+}
+
 fn main() i32 {
   borrowing()
   aliasing()
@@ -212,5 +226,6 @@ fn main() i32 {
   bytes()
   globals()
   members()
+  allocated()
   0i32
 }

--- a/test/cases/collection/collection-success.out
+++ b/test/cases/collection/collection-success.out
@@ -23,3 +23,7 @@ global-slice-len = 3
 write-through-global-slice = 111
 member-slice-len = 4
 write-through-member-slice = 33
+allocated-slice-len = 3
+allocated-first = 11
+allocated-middle = 22
+allocated-last = 33

--- a/test/cases/move/cases.toml
+++ b/test/cases/move/cases.toml
@@ -29,6 +29,11 @@
 #   for struct fields. The compiler treats both the same way, permitting the move
 #   and deactivating the whole container; move-flow-aggregate asserts what it
 #   actually does.
+#
+# move-flow-aggregate covers moving a value *out of* an aggregate. Moving one
+# *into* one is move-flow-literal, and it is an xfail: a type literal's field
+# initializers never reach flowHandleMoveOrCopy, so the source stays active. That
+# gap is also why region-owning-field-so double-frees.
 
 support = []
 
@@ -55,3 +60,11 @@ tags = ["flow"]
 category = "reject"
 description = "Moving out of a field, an array element, or a global"
 tags = ["flow"]
+
+# -------- known defects --------
+
+[scenario.move-flow-literal]
+category = "reject"
+description = "Naming a move value in a type literal's field does not deactivate the source"
+tags = ["flow"]
+xfail = true

--- a/test/cases/move/cases.toml
+++ b/test/cases/move/cases.toml
@@ -31,9 +31,11 @@
 #   actually does.
 #
 # move-flow-aggregate covers moving a value *out of* an aggregate. Moving one
-# *into* one is move-flow-literal, and it is an xfail: a type literal's field
-# initializers never reach flowHandleMoveOrCopy, so the source stays active. That
-# gap is also why region-owning-field-so double-frees.
+# *into* one is move-flow-literal for a type literal, which is fixed, and
+# move-flow-arraylit for an array literal, which is not. The array case is held
+# back by a question rather than by effort: a fill literal '[n; value]' repeats
+# one expression across n elements, and what that does to a move value or to a
+# counted reference has not been decided.
 
 support = []
 
@@ -61,10 +63,15 @@ category = "reject"
 description = "Moving out of a field, an array element, or a global"
 tags = ["flow"]
 
-# -------- known defects --------
-
 [scenario.move-flow-literal]
 category = "reject"
-description = "Naming a move value in a type literal's field does not deactivate the source"
+description = "Naming a move value in a type literal's field deactivates the source"
+tags = ["flow"]
+
+# -------- known defects --------
+
+[scenario.move-flow-arraylit]
+category = "reject"
+description = "Naming a move value in an array literal's element does not deactivate the source"
 tags = ["flow"]
 xfail = true

--- a/test/cases/move/cases.toml
+++ b/test/cases/move/cases.toml
@@ -31,11 +31,12 @@
 #   actually does.
 #
 # move-flow-aggregate covers moving a value *out of* an aggregate. Moving one
-# *into* one is move-flow-literal for a type literal, which is fixed, and
-# move-flow-arraylit for an array literal, which is not. The array case is held
-# back by a question rather than by effort: a fill literal '[n; value]' repeats
-# one expression across n elements, and what that does to a move value or to a
-# counted reference has not been decided.
+# *into* one is move-flow-literal for a type literal and move-flow-arraylit for
+# an array literal. The array literal has a second form, the fill '[n; value]',
+# which repeats one expression across n elements; a move value has one owner and
+# cannot have n, so a fill of one is refused and move-flow-arraylit asserts that
+# too. What the same fill does to a *counted* reference is a count rather than a
+# refusal, and region owns it.
 
 support = []
 
@@ -68,10 +69,7 @@ category = "reject"
 description = "Naming a move value in a type literal's field deactivates the source"
 tags = ["flow"]
 
-# -------- known defects --------
-
 [scenario.move-flow-arraylit]
 category = "reject"
-description = "Naming a move value in an array literal's element does not deactivate the source"
+description = "Naming a move value in an array literal's element deactivates the source, and a fill literal refuses one"
 tags = ["flow"]
-xfail = true

--- a/test/cases/move/move-flow-arraylit.cone
+++ b/test/cases/move/move-flow-arraylit.cone
@@ -1,15 +1,20 @@
-// Defect: naming a move value in an array literal's element does not deactivate
-// the source, so the value can still be read after it was moved away.
+// Naming a move value in an array literal's element deactivates the source, and
+// the fill form of the same literal refuses a move value outright.
 //
-// This is the sibling of move-flow-literal, which covers a type literal and is
-// fixed: ArrayLitTag is still treated as a leaf by flowLoadValue, so its elements
-// never reach flowHandleMoveOrCopy.
+// The list form '[a, b]' gives every element a holder of its own, so each value
+// is moved or copied on the same rule as a function call's argument: arrayLitFlow
+// hands each one to flowHandleMoveOrCopy, exactly as move-flow-literal's type
+// literal does with its field values.
 //
-// It is not the same fix, because an array literal has a second form. A fill
-// literal '[n; value]' repeats one expression across n elements, so a move value
-// would have to be moved into n slots -- which cannot be right for one owner --
-// and a counted reference would need n added rather than one. What a fill does to
-// a move or counted value is an open question; the list form below is not.
+// The fill form '[n; value]' is the other thing an array literal can be, and it
+// is where the two differ. It evaluates one expression and stores it into every
+// element, and a move value has exactly one owner, so there is nothing for the
+// second element to hold. It is refused however small n is: proving that n is 1
+// would buy a construct nobody writes, at the cost of a rule that is harder to
+// state than "a fill may not repeat a move value".
+//
+// While array literals were treated as leaves by flow analysis, both forms
+// compiled clean and the read below was a use after move.
 
 struct @move Handle {
   id i32
@@ -18,5 +23,9 @@ struct @move Handle {
 fn main() i32 {
   imm hd = Handle[7]
   imm arr [2; Handle] = [hd, Handle[8]]
+
+  imm two [2; Handle] = [2; Handle[9]]      //~ ErrorBadFill "may not repeat a move value"
+  imm one [1; Handle] = [1; Handle[10]]     //~ ErrorBadFill "may not repeat a move value"
+
   hd.id                     //~ ErrorMove
 }

--- a/test/cases/move/move-flow-arraylit.cone
+++ b/test/cases/move/move-flow-arraylit.cone
@@ -1,0 +1,22 @@
+// Defect: naming a move value in an array literal's element does not deactivate
+// the source, so the value can still be read after it was moved away.
+//
+// This is the sibling of move-flow-literal, which covers a type literal and is
+// fixed: ArrayLitTag is still treated as a leaf by flowLoadValue, so its elements
+// never reach flowHandleMoveOrCopy.
+//
+// It is not the same fix, because an array literal has a second form. A fill
+// literal '[n; value]' repeats one expression across n elements, so a move value
+// would have to be moved into n slots -- which cannot be right for one owner --
+// and a counted reference would need n added rather than one. What a fill does to
+// a move or counted value is an open question; the list form below is not.
+
+struct @move Handle {
+  id i32
+}
+
+fn main() i32 {
+  imm hd = Handle[7]
+  imm arr [2; Handle] = [hd, Handle[8]]
+  hd.id                     //~ ErrorMove
+}

--- a/test/cases/move/move-flow-literal.cone
+++ b/test/cases/move/move-flow-literal.cone
@@ -1,0 +1,25 @@
+// Defect: naming a move value in a type literal's field does not deactivate the
+// source variable, so the value can still be read after it was moved away.
+//
+// Passing the same value as a call argument does deactivate it -- move-success
+// and move-flow-deactivate cover that -- so the gap is specific to how a literal
+// initializes its fields. flowHandleMoveOrCopy is never reached for them.
+//
+// This is why a region-allocated struct owning a '+so' reference double-frees;
+// region-owning-field-so records that consequence. Closing it decides whether a
+// literal moves or copies its initializers, which is a language question rather
+// than a code generation one.
+
+struct @move Handle {
+  id i32
+}
+
+struct Box {
+  h Handle
+}
+
+fn main() i32 {
+  imm hd = Handle[7]
+  imm boxed = Box[hd]
+  hd.id                     //~ ErrorMove
+}

--- a/test/cases/move/move-flow-literal.cone
+++ b/test/cases/move/move-flow-literal.cone
@@ -1,14 +1,15 @@
-// Defect: naming a move value in a type literal's field does not deactivate the
-// source variable, so the value can still be read after it was moved away.
+// Naming a move value in a type literal's field deactivates the source, exactly
+// as passing it to a call does.
 //
-// Passing the same value as a call argument does deactivate it -- move-success
-// and move-flow-deactivate cover that -- so the gap is specific to how a literal
-// initializes its fields. flowHandleMoveOrCopy is never reached for them.
+// A type literal initializes its fields from expressions, so each value is moved
+// or copied on the same rule as a function call's argument: typeLitFlow hands
+// each one to flowHandleMoveOrCopy. A value given by field name is wrapped in a
+// NamedValNode, which is unwrapped first so the decision is made about the value.
 //
-// This is why a region-allocated struct owning a '+so' reference double-frees;
-// region-owning-field-so records that consequence. Closing it decides whether a
-// literal moves or copies its initializers, which is a language question rather
-// than a code generation one.
+// While literals were treated as leaves by flow analysis this read compiled
+// clean, and a region-allocated struct owning a '+so' reference double-freed
+// because its source variable was never deactivated. region-owning-field-so is
+// that case.
 
 struct @move Handle {
   id i32

--- a/test/cases/region/cases.toml
+++ b/test/cases/region/cases.toml
@@ -86,8 +86,11 @@
 # inner allocation's own branches had already displaced, so it read the block back
 # from the builder instead.
 #
-# One xfail remains, and it is not code generation ignoring an earlier phase:
-# region-fill-count waits on an array literal being generatable at all.
+# No xfail remains. The last one was region-fill-count, and what it was waiting
+# on was not this group's: an array literal built as a constant array could not
+# hold an allocation, so the fill did not survive module verification and the
+# amount had nowhere to be read. array-nonconst-literal fixed that, and the two
+# llvmir checks the amount had been waiting for now assert it.
 
 support = []
 
@@ -131,19 +134,26 @@ category = "run"
 description = "Releasing a region-allocated struct releases the '+so' reference its field owns, once"
 tags = ["flow", "genllvm", "runtime"]
 
-# -------- known defects --------
-
-# The amount is the whole claim, and no run could see it anyway: too low frees
-# the allocation while the array still points at it, too high leaks it, and
-# stdout shows neither. It carries no llvmir check yet, because there is no
-# generated code to check -- the literal itself does not survive module
-# verification, for a reason array-nonconst-literal owns. Written without one
-# rather than with a needle nothing has ever produced.
+# The amount is the whole claim, and no run could see it: too low frees the
+# allocation while the array still points at it, too high leaks it, and stdout
+# shows neither. So it is a 'compile' carrying llvmir checks, which is the one
+# place the number appears. The register numbers below were read out of the dump
+# rather than chosen; the two functions are the same shape up to the amount, so
+# 12 against 11 is exactly the lvalue-versus-temporary difference being asserted.
 [scenario.region-fill-count]
 category = "compile"
 description = "An array fill literal counting its value into every element: n holders from an lvalue, n-1 from a temporary"
 tags = ["flow", "genllvm"]
-xfail = true
+
+[[scenario.region-fill-count.check]]
+name = "fill-from-lvalue-counts-n"
+target = "llvmir"
+contains = ["add i64 %5, 12"]
+
+[[scenario.region-fill-count.check]]
+name = "fill-from-temporary-counts-n-minus-one"
+target = "llvmir"
+contains = ["add i64 %5, 11"]
 
 # -------- parse stage --------
 

--- a/test/cases/region/cases.toml
+++ b/test/cases/region/cases.toml
@@ -67,10 +67,13 @@
 # region-typecheck-coerce pins the direction that must stay refused, which could
 # not be asserted while the coercion rule read backwards.
 #
-# Two xfails remain, and neither is code generation ignoring an earlier phase:
-# region-nested-alloc is a block-structure bug in the allocation path, and
-# region-owning-field-so waits on move semantics for type literals, which
-# move-flow-literal owns.
+# The pair of owning-field scenarios are the same shape in the two regions, and
+# together they are what reference counting means here: region-owning-field's 'rc'
+# field is a second holder and is counted, while region-owning-field-so's '+so'
+# field is the only holder, so naming it in the literal moves it.
+#
+# One xfail remains, and it is not code generation ignoring an earlier phase:
+# region-nested-alloc is a block-structure bug in the allocation path.
 
 support = []
 
@@ -101,18 +104,17 @@ category = "compile"
 description = "An owning reference coerces to a borrowed reference"
 tags = ["typecheck"]
 
+[scenario.region-owning-field-so]
+category = "run"
+description = "Releasing a region-allocated struct releases the '+so' reference its field owns, once"
+tags = ["flow", "genllvm", "runtime"]
+
 # -------- known defects --------
 
 [scenario.region-nested-alloc]
 category = "compile"
 description = "An allocation nested inside another allocation fails module verification"
 tags = ["genllvm"]
-xfail = true
-
-[scenario.region-owning-field-so]
-category = "run"
-description = "Releasing a region-allocated struct that owns a '+so' reference frees it twice"
-tags = ["flow", "genllvm", "runtime"]
 xfail = true
 
 # -------- parse stage --------

--- a/test/cases/region/cases.toml
+++ b/test/cases/region/cases.toml
@@ -21,6 +21,8 @@
 #   allocation to be possible at all: its '_alloc' method.
 # - region-typecheck-init asks the same about the optional 'init' method, for a
 #   region and for a permission.
+# - region-typecheck-coerce asks which coercions between regions are allowed,
+#   which is a rule about reference types rather than about allocating.
 #
 # region-flow is a single function, because data-flow analysis runs per function
 # and only while the error count is zero (ir/stmt/fndcl.c:181): the first
@@ -57,11 +59,18 @@
 #   a literal, so 'mut g = +rc-mut 80' is ErrorNotLit -- a fact about global
 #   initialization, which core owns, rather than about regions.
 #
-# The five xfail scenarios each name one defect in their header comment. Four are
-# code generation ignoring what the earlier phases decided, and the fifth is a
-# coercion rule that reads backwards; together they are why region-success keeps
-# an owning reference in one variable, allocates a struct's owning field before
-# the literal that names it, and reaches a borrow through '&*r'.
+# Four defects this group recorded as xfails are now fixed, and their scenarios
+# assert the behavior instead: a moved 'so' reference frees once, a first
+# assignment to an uninitialized owning variable releases nothing, a region-
+# allocated struct's 'rc' owning field is released through the reference it holds
+# rather than its address, and an owning reference coerces to a borrowed one.
+# region-typecheck-coerce pins the direction that must stay refused, which could
+# not be asserted while the coercion rule read backwards.
+#
+# Two xfails remain, and neither is code generation ignoring an earlier phase:
+# region-nested-alloc is a block-structure bug in the allocation path, and
+# region-owning-field-so waits on move semantics for type literals, which
+# move-flow-literal owns.
 
 support = []
 
@@ -72,25 +81,27 @@ category = "run"
 description = "Allocating in a region, reference counting, single ownership, permissions, and owning references through fields, calls and branches"
 tags = ["parse", "nameres", "typecheck", "flow", "genllvm", "runtime"]
 
-# -------- known defects --------
-
 [scenario.region-so-move]
 category = "run"
-description = "Moving a 'so' reference between variables frees it twice"
-tags = ["genllvm", "runtime"]
-xfail = true
+description = "Moving a 'so' reference between variables transfers ownership, and frees it once"
+tags = ["flow", "genllvm", "runtime"]
 
 [scenario.region-owning-field]
 category = "run"
-description = "Releasing a region-allocated struct that owns a reference corrupts the heap"
+description = "Releasing a region-allocated struct releases the 'rc' reference its field owns"
 tags = ["genllvm", "runtime"]
-xfail = true
 
 [scenario.region-uninit-owning]
 category = "run"
-description = "Assigning to an owning-reference variable declared without an initial value releases uninitialized storage"
-tags = ["genllvm", "runtime"]
-xfail = true
+description = "Assigning to an owning-reference variable declared without an initial value releases nothing first"
+tags = ["flow", "genllvm", "runtime"]
+
+[scenario.region-borrow-coerce]
+category = "compile"
+description = "An owning reference coerces to a borrowed reference"
+tags = ["typecheck"]
+
+# -------- known defects --------
 
 [scenario.region-nested-alloc]
 category = "compile"
@@ -98,10 +109,10 @@ description = "An allocation nested inside another allocation fails module verif
 tags = ["genllvm"]
 xfail = true
 
-[scenario.region-borrow-coerce]
-category = "compile"
-description = "An owning reference does not coerce to a borrowed reference"
-tags = ["typecheck"]
+[scenario.region-owning-field-so]
+category = "run"
+description = "Releasing a region-allocated struct that owns a '+so' reference frees it twice"
+tags = ["flow", "genllvm", "runtime"]
 xfail = true
 
 # -------- parse stage --------
@@ -131,6 +142,12 @@ category = "reject"
 description = "The 'init' method a region or a permission may declare, and its required shape"
 tags = ["typecheck"]
 diagnostics = 4
+
+[scenario.region-typecheck-coerce]
+category = "reject"
+description = "The region coercions that must stay refused: a borrow standing in for an allocation, and one region's allocation for another's"
+tags = ["typecheck"]
+diagnostics = 3
 
 # -------- flow stage --------
 

--- a/test/cases/region/cases.toml
+++ b/test/cases/region/cases.toml
@@ -51,6 +51,10 @@
 #   handling is the unimplemented part; an xfail here would record a crash
 #   rather than a defect in a feature that otherwise works.
 # - Array allocation, '+[]'. Array references and slices belong to collection.
+#   region-flow-fill is the one line of it here, and it is there for the count a
+#   fill literal asks for rather than for the array reference: it is the only
+#   syntax that reaches a run-time element count, because the plain literal form
+#   insists its dimension be a constant.
 # - Virtual owning references, '+<'. They belong to trait.
 # - ErrorBadAlloc (1036), "Missing valid alloc methods", which sounds like this
 #   group's and is dead: ir/types/region.c raises every allocator complaint as
@@ -72,8 +76,15 @@
 # field is a second holder and is counted, while region-owning-field-so's '+so'
 # field is the only holder, so naming it in the literal moves it.
 #
-# One xfail remains, and it is not code generation ignoring an earlier phase:
-# region-nested-alloc is a block-structure bug in the allocation path.
+# region-fill-count is the same question asked of an array fill literal, which
+# makes n holders out of one value at once. The 'move' group owns the other half
+# of that literal -- a move value may not be filled at all, which move-flow-arraylit
+# asserts -- and region-flow-fill covers the two counts the constant alias amount
+# cannot carry.
+#
+# Two xfails remain, and neither is code generation ignoring an earlier phase:
+# region-nested-alloc is a block-structure bug in the allocation path, and
+# region-fill-count waits on an array literal being generatable at all.
 
 support = []
 
@@ -110,6 +121,18 @@ description = "Releasing a region-allocated struct releases the '+so' reference 
 tags = ["flow", "genllvm", "runtime"]
 
 # -------- known defects --------
+
+# The amount is the whole claim, and no run could see it anyway: too low frees
+# the allocation while the array still points at it, too high leaks it, and
+# stdout shows neither. It carries no llvmir check yet, because there is no
+# generated code to check -- the literal itself does not survive module
+# verification, for a reason array-nonconst-literal owns. Written without one
+# rather than with a needle nothing has ever produced.
+[scenario.region-fill-count]
+category = "compile"
+description = "An array fill literal counting its value into every element: n holders from an lvalue, n-1 from a temporary"
+tags = ["flow", "genllvm"]
+xfail = true
 
 [scenario.region-nested-alloc]
 category = "compile"
@@ -158,3 +181,9 @@ category = "reject"
 description = "Owning references that move rather than copy, and a permission that forbids the write"
 tags = ["flow"]
 diagnostics = 3
+
+[scenario.region-flow-fill]
+category = "reject"
+description = "The element counts an array fill literal cannot count a reference into: too many, and not known until run time"
+tags = ["flow"]
+diagnostics = 2

--- a/test/cases/region/cases.toml
+++ b/test/cases/region/cases.toml
@@ -63,7 +63,7 @@
 #   a literal, so 'mut g = +rc-mut 80' is ErrorNotLit -- a fact about global
 #   initialization, which core owns, rather than about regions.
 #
-# Four defects this group recorded as xfails are now fixed, and their scenarios
+# Five defects this group recorded as xfails are now fixed, and their scenarios
 # assert the behavior instead: a moved 'so' reference frees once, a first
 # assignment to an uninitialized owning variable releases nothing, a region-
 # allocated struct's 'rc' owning field is released through the reference it holds
@@ -82,8 +82,11 @@
 # asserts -- and region-flow-fill covers the two counts the constant alias amount
 # cannot carry.
 #
-# Two xfails remain, and neither is code generation ignoring an earlier phase:
-# region-nested-alloc is a block-structure bug in the allocation path, and
+# region-nested-alloc joined them: genlallocref's phi named a predecessor that the
+# inner allocation's own branches had already displaced, so it read the block back
+# from the builder instead.
+#
+# One xfail remains, and it is not code generation ignoring an earlier phase:
 # region-fill-count waits on an array literal being generatable at all.
 
 support = []
@@ -94,6 +97,14 @@ support = []
 category = "run"
 description = "Allocating in a region, reference counting, single ownership, permissions, and owning references through fields, calls and branches"
 tags = ["parse", "nameres", "typecheck", "flow", "genllvm", "runtime"]
+
+# Separate from region-success because it is the scenario a code generation fix
+# landed with: without it, genlallocref's phi named a predecessor that the inner
+# allocation's branches had already displaced, and the module failed verification.
+[scenario.region-nested-alloc]
+category = "run"
+description = "An allocation whose initial value holds another allocation"
+tags = ["genllvm", "runtime"]
 
 [scenario.region-so-move]
 category = "run"
@@ -132,12 +143,6 @@ tags = ["flow", "genllvm", "runtime"]
 category = "compile"
 description = "An array fill literal counting its value into every element: n holders from an lvalue, n-1 from a temporary"
 tags = ["flow", "genllvm"]
-xfail = true
-
-[scenario.region-nested-alloc]
-category = "compile"
-description = "An allocation nested inside another allocation fails module verification"
-tags = ["genllvm"]
 xfail = true
 
 # -------- parse stage --------

--- a/test/cases/region/region-borrow-coerce.cone
+++ b/test/cases/region/region-borrow-coerce.cone
@@ -1,20 +1,11 @@
-// Defect: an owning reference does not coerce to a borrowed reference, and a
-// borrowed reference does coerce to an owning one. The two directions are
-// exactly backwards.
+// An owning reference coerces to a borrowed reference.
 //
-// regionMatches in ir/types/reference.c decides whether one reference's region
-// may stand in for another's, and returns CastSubtype when its 'to' argument is
-// the borrow region. refMatches calls it as regionMatches(from->region,
-// to->region), so the parameter it tests as the target is the source, and the
-// rule reads in reverse: an allocation may be passed where a borrow is wanted
-// only in the direction that is unsound.
+// regionMatches returns CastSubtype when its 'to' argument is the borrow region,
+// so an allocation may be passed wherever a borrow is wanted. refMatches passes
+// its arguments in that order; passing them reversed made the rule read backwards,
+// rejecting this coercion and accepting the unsound one instead.
 //
-// Only the rejecting half can be asserted. The accepting half compiles clean and
-// runs, handing a stack address to a parameter typed as an owning reference; a
-// scenario for it would have to claim a diagnostic that never comes.
-//
-// The success program routes around this with '&*r', which borrows from what the
-// owning reference points at and yields an ordinary borrowed reference.
+// region-typecheck-coerce asserts the direction that must stay refused.
 
 fn onlyReads(n &i32) i32 { *n }
 

--- a/test/cases/region/region-fill-count.cone
+++ b/test/cases/region/region-fill-count.cone
@@ -1,0 +1,35 @@
+// Defect: an array fill literal holding a counted reference cannot be generated,
+// so the count it asks for cannot be asserted against generated code.
+//
+// The count is how many holders exist, which region-success establishes for a
+// single binding: an lvalue keeps its reference, so copying from one adds a
+// holder, while a temporary hands over the reference it was born holding and
+// adds none. A fill '[n; value]' stores one value into n elements, so the amount
+// is n from an lvalue and n-1 from a temporary, and the non-fill case is exactly
+// n = 1. Flow analysis injects that amount today; what fails is behind it.
+//
+// The cause is not in this group and has nothing to do with regions. An array
+// literal is generated with LLVMConstArray, so any element that is the result of
+// an instruction -- and an allocation always is -- builds a constant array with
+// instruction operands, which the module verifier rejects. array-nonconst-literal
+// records that with an i32.
+//
+// This is what will assert the amount once the literal generates: a leak and a
+// use after free are equally silent on stdout, so the counter adjustment in the
+// generated IR is the only place the number is visible.
+//
+// Neither allocation below is ever released. An array whose elements are owning
+// references is not walked at scope exit -- flowScopeDealias visits variables
+// whose own type is an owning reference, and an array's is not -- so both leak.
+// Counting n holders is still what makes that a leak rather than a use after
+// free, which is what the count did before an array literal reached flow
+// analysis at all.
+
+fn fillFromLval() {
+  imm r = +rc-mut 7i32
+  imm arr = [12; r]
+}
+
+fn fillFromTemp() {
+  imm arr = [12; +rc-mut 8i32]
+}

--- a/test/cases/region/region-fill-count.cone
+++ b/test/cases/region/region-fill-count.cone
@@ -1,37 +1,32 @@
-// Defect: an array fill literal holding a counted reference cannot be generated,
-// so the count it asks for cannot be asserted against generated code.
+// An array fill literal holding a counted reference asks for one alias amount
+// covering every element it makes, and this asserts the number.
 //
 // The count is how many holders exist, which region-success establishes for a
 // single binding: an lvalue keeps its reference, so copying from one adds a
 // holder, while a temporary hands over the reference it was born holding and
 // adds none. A fill '[n; value]' stores one value into n elements, so the amount
 // is n from an lvalue and n-1 from a temporary, and the non-fill case is exactly
-// n = 1. Flow analysis injects that amount today; what fails is behind it.
+// n = 1. Flow analysis injects that amount once, ahead of the elements, so it
+// reaches the counter as a single add rather than as n of them.
 //
-// The cause is not in this group and has nothing to do with regions. An array
-// literal is generated with LLVMConstArray, so any element that is the result of
-// an instruction -- and an allocation always is -- builds a constant array with
-// instruction operands, which the module verifier rejects. array-nonconst-literal
-// records that with an i32.
+// The amount is the whole claim and no run could see it: too low frees the
+// allocation while the array still points at it, too high leaks it, and stdout
+// shows neither. So the counter adjustment in the generated IR is the only place
+// the number is visible, and the two llvmir checks in cases.toml read it there --
+// 'add i64 %5, 12' for the fill below that copies from an lvalue, and
+// 'add i64 %5, 11' for the one that consumes a temporary. That is why this stays
+// a 'compile' scenario carrying checks rather than becoming a 'run'.
 //
-// This is what will assert the amount once the literal generates: a leak and a
-// use after free are equally silent on stdout, so the counter adjustment in the
-// generated IR is the only place the number is visible.
-//
-// So this scenario is deliberately an xfail carrying no check, and it is the
-// signal as much as the record. The day array-nonconst-literal is fixed this
-// compiles, flips to XPASS and fails the suite -- and the work that falls due at
-// that moment is to add the two llvmir checks the amount has been waiting for:
-// 'add i64 %<n>, 12' from the lvalue fill below, and 'add i64 %<n>, 11' from the
-// temporary. Until then the amount is emitted and correct but unasserted, which
-// is the one thing about it worth not forgetting.
+// This could not be asserted until an array literal generated at all. Both forms
+// were built as a constant array, which cannot hold the result of an instruction
+// and an allocation always is, so the module failed verification before any of
+// this was reachable; array-nonconst-literal owns that fix.
 //
 // Neither allocation below is ever released. An array whose elements are owning
 // references is not walked at scope exit -- flowScopeDealias visits variables
 // whose own type is an owning reference, and an array's is not -- so both leak.
 // Counting n holders is still what makes that a leak rather than a use after
-// free, which is what the count did before an array literal reached flow
-// analysis at all.
+// free, which is what the count is for.
 
 fn fillFromLval() {
   imm r = +rc-mut 7i32

--- a/test/cases/region/region-fill-count.cone
+++ b/test/cases/region/region-fill-count.cone
@@ -18,6 +18,14 @@
 // use after free are equally silent on stdout, so the counter adjustment in the
 // generated IR is the only place the number is visible.
 //
+// So this scenario is deliberately an xfail carrying no check, and it is the
+// signal as much as the record. The day array-nonconst-literal is fixed this
+// compiles, flips to XPASS and fails the suite -- and the work that falls due at
+// that moment is to add the two llvmir checks the amount has been waiting for:
+// 'add i64 %<n>, 12' from the lvalue fill below, and 'add i64 %<n>, 11' from the
+// temporary. Until then the amount is emitted and correct but unasserted, which
+// is the one thing about it worth not forgetting.
+//
 // Neither allocation below is ever released. An array whose elements are owning
 // references is not walked at scope exit -- flowScopeDealias visits variables
 // whose own type is an owning reference, and an array's is not -- so both leak.

--- a/test/cases/region/region-flow-fill.cone
+++ b/test/cases/region/region-flow-fill.cone
@@ -1,0 +1,22 @@
+// The two counts a fill literal cannot express for a counted reference.
+//
+// region-fill-count asserts the amount a fill adds when it can be worked out:
+// n holders, or n-1 from a temporary. That amount is a constant in the injected
+// alias node, so there are two ways to ask for one the node cannot carry, and
+// both are refused rather than counted wrongly -- an undercount frees the
+// allocation while the array still points at it.
+//
+// Both diagnostics are in one function on purpose. Data-flow analysis runs per
+// function and only while the error count is zero (ir/stmt/fndcl.c:181), so the
+// first function to raise one silences flow analysis for every later function.
+//
+// The second line is the only syntax that reaches a run-time element count: the
+// plain literal form insists its dimension be a constant, and '+[]region-perm'
+// array allocation does not. It appears here for the count rather than for the
+// array reference, which stays collection's subject.
+
+fn fills(n usize) {
+  imm r = +rc-mut 7i32
+  imm many = [40000; r]              //~ ErrorBadFill "too many elements"
+  imm sized = +[]rc-mut [n; r]       //~ ErrorBadFill "known at compile time"
+}

--- a/test/cases/region/region-flow-fill.cone
+++ b/test/cases/region/region-flow-fill.cone
@@ -17,6 +17,6 @@
 
 fn fills(n usize) {
   imm r = +rc-mut 7i32
-  imm many = [40000; r]              //~ ErrorBadFill "too many elements"
-  imm sized = +[]rc-mut [n; r]       //~ ErrorBadFill "known at compile time"
+  imm many = [40000; r]              //~ ErrorFillCount "too many elements"
+  imm sized = +[]rc-mut [n; r]       //~ ErrorFillCount "known at compile time"
 }

--- a/test/cases/region/region-nested-alloc.cone
+++ b/test/cases/region/region-nested-alloc.cone
@@ -1,17 +1,28 @@
-// Defect: an allocation whose initial value contains another allocation fails
-// LLVM module verification.
+// An allocation nested inside another allocation: the value a '+region-perm'
+// expression allocates may itself hold one, and both survive into the value the
+// outer allocation returns.
 //
-// genlallocref in genllvm/genlalloc.c records the block it is in, emits the
-// allocation's null check as a branch to a panic block and an init block, and
-// finishes with a phi over those two. Generating the initial value happens
-// between those steps, so an inner allocation splits the block the outer one is
-// building in, and the phi names predecessors that are no longer the ones
-// reaching it. The compiler reports ErrorGenErr, with no source line, and then
-// dies on an access violation carrying the broken module further, so the
-// scenario asserts nothing beyond the failure itself.
+// Both are printed rather than merely compiled, because the module verifying is
+// the weaker half of what is worth asserting here. genlallocref emits its
+// allocator's null check as a branch to a panic block and an init block and ends
+// with a phi over the two, and it generates the initial value in between. An
+// inner allocation emits branches of its own while that is happening, so the
+// block reaching the phi is no longer the block the outer allocation was
+// positioned in, and each incoming edge has to be read back from the builder
+// rather than remembered from before the value was generated.
 //
-// The success program therefore allocates a struct's owning field first, into a
-// variable, and names the variable in the literal.
+// The outer allocation is never released: its count is raised on the way into
+// the variable and lowered once on the way out, so it never reaches zero. That
+// is region-uninit-owning's and region-owning-field's subject, not this one's.
+
+import stdio::*
+
+fn show(label &[]u8, n i64) {
+  printStr(label)
+  printStr(" = ")
+  printInt(n)
+  printStr("\n")
+}
 
 struct Held {
   r +rc-mut i32
@@ -20,4 +31,11 @@ struct Held {
 
 fn f() {
   imm h = +rc-mut Held[r: +rc-mut 40, n: 41]
+  show("nested-inner-allocation", i64[*h.r])
+  show("outer-field-beside-it", i64[h.n])
+}
+
+fn main() i32 {
+  f()
+  0i32
 }

--- a/test/cases/region/region-nested-alloc.out
+++ b/test/cases/region/region-nested-alloc.out
@@ -1,0 +1,2 @@
+nested-inner-allocation = 40
+outer-field-beside-it = 41

--- a/test/cases/region/region-owning-field-so.cone
+++ b/test/cases/region/region-owning-field-so.cone
@@ -1,16 +1,13 @@
-// Defect: releasing a region-allocated struct that owns a '+so' reference
-// corrupts the heap, even though the same shape with an 'rc' field works --
-// region-owning-field asserts that one.
+// Releasing a region-allocated struct that owns a '+so' reference frees that
+// reference once, through the single owner the struct's field became.
 //
-// The cause is not in this group. A type literal's field initializers do not
-// apply move semantics, so naming 'inner' in the literal never deactivates it.
-// The variable stays on the scope's dealias list and frees the allocation that
-// the struct's field now also owns, so the release path runs twice. The same gap
-// is a use-after-move hole in its own right, which move-flow-literal records.
+// The literal's field value moves, so naming 'inner' there deactivates it and it
+// leaves the scope's dealias list. Only the struct's field releases the
+// allocation. While literals were treated as leaves by flow analysis, both the
+// variable and the field released it and the run corrupted the heap.
 //
-// Loading the field in genlDealiasFlds -- the fix region-owning-field needed --
-// does not help here: the second release is the source variable's, not the
-// field's. This one waits on the move semantics being settled.
+// region-owning-field is the same shape with an 'rc' field, where the second
+// holder is counted rather than forbidden.
 
 import stdio::*
 

--- a/test/cases/region/region-owning-field-so.cone
+++ b/test/cases/region/region-owning-field-so.cone
@@ -1,0 +1,37 @@
+// Defect: releasing a region-allocated struct that owns a '+so' reference
+// corrupts the heap, even though the same shape with an 'rc' field works --
+// region-owning-field asserts that one.
+//
+// The cause is not in this group. A type literal's field initializers do not
+// apply move semantics, so naming 'inner' in the literal never deactivates it.
+// The variable stays on the scope's dealias list and frees the allocation that
+// the struct's field now also owns, so the release path runs twice. The same gap
+// is a use-after-move hole in its own right, which move-flow-literal records.
+//
+// Loading the field in genlDealiasFlds -- the fix region-owning-field needed --
+// does not help here: the second release is the source variable's, not the
+// field's. This one waits on the move semantics being settled.
+
+import stdio::*
+
+fn show(label &[]u8, n i64) {
+  printStr(label)
+  printStr(" = ")
+  printInt(n)
+  printStr("\n")
+}
+
+struct HeldSo {
+  r +so i32
+}
+
+fn f() {
+  imm inner = +so 5
+  imm outer = +so HeldSo[r: inner]
+  show("so-owning-field", i64[*outer.r])
+}
+
+fn main() i32 {
+  f()
+  0i32
+}

--- a/test/cases/region/region-owning-field-so.out
+++ b/test/cases/region/region-owning-field-so.out
@@ -1,0 +1,1 @@
+so-owning-field = 5

--- a/test/cases/region/region-owning-field.cone
+++ b/test/cases/region/region-owning-field.cone
@@ -1,17 +1,16 @@
-// Defect: releasing a region-allocated struct that owns a reference corrupts the
-// heap.
+// Releasing a region-allocated struct that owns an 'rc' reference releases the
+// field's referent too.
 //
-// genlDealiasFlds in genllvm/genlalloc.c reaches an owning field with a struct
-// GEP, which yields the address of the field, and hands that straight to
-// genlRcCounter or genlDealiasOwn -- both of which expect the reference the
-// field holds, not a pointer to it. The counter it then decrements is whatever
-// sits eight bytes before the field, and the pointer it may free is the field's
-// own address. The run aborts before printing anything.
+// genlDealiasFlds reaches an owning field with a struct GEP, which yields the
+// address of the field, and loads the reference the field holds before handing it
+// to the release path. Without the load the counter decremented is whatever sits
+// eight bytes before the field.
 //
-// A struct with an owning field is fine on the stack, which is what the success
-// program uses: genlDealiasNodes only walks variables whose own type is an
-// owning reference, so a stack struct's fields are never released at all. The
-// defect needs the struct itself to be region-allocated.
+// A struct with an owning field on the stack is a different path: genlDealiasNodes
+// only walks variables whose own type is an owning reference, so a stack struct's
+// fields are never released at all. This scenario needs the struct itself to be
+// region-allocated. The '+so' owning field is still broken; see
+// region-owning-field-so.
 
 import stdio::*
 

--- a/test/cases/region/region-so-move.cone
+++ b/test/cases/region/region-so-move.cone
@@ -1,15 +1,10 @@
-// Defect: a 'so' reference moved from one variable to another is freed twice.
+// Moving a 'so' reference from one variable to another transfers ownership: the
+// allocation is freed once, by the new owner, at the end of the scope.
 //
-// Flow analysis gets this right -- it deactivates the source, which region-flow
-// asserts -- but code generation does not use that result. genlDealiasNodes in
-// genllvm/genlalloc.c walks every variable declared in the block and frees each
-// one whose type is an owning reference, with no notion of a variable whose
-// value was moved out, so both names free the one allocation. The run aborts
-// with a heap corruption before it prints anything.
-//
-// This is the whole reason the success program never lets a 'so' reference land
-// in two variables. Without the defect, single-owner semantics are what the
-// region is for: moving the owner is the ordinary way to pass one along.
+// Single-owner semantics are what the region is for, and moving the owner is the
+// ordinary way to pass one along. Flow analysis deactivates the source, which
+// region-flow asserts; flowScopeDealias then leaves a deactivated variable off
+// the scope's dealias list, so only the surviving owner releases.
 
 import stdio::*
 

--- a/test/cases/region/region-success.cone
+++ b/test/cases/region/region-success.cone
@@ -13,11 +13,14 @@
 // struct with an '_alloc' method and nothing in the compiler restricts the set
 // to the two built in.
 //
-// Five things are deliberately absent, each with its own xfail scenario naming
-// the defect: moving a '+so' reference between variables, an allocation nested
-// inside another allocation, releasing a region-allocated struct that owns a
-// reference, assigning to an 'rc' variable declared without an initial value,
-// and passing an owning reference to a parameter expecting a borrowed one.
+// Four things are deliberately absent, each with its own xfail scenario naming
+// the defect: moving a '+so' reference between variables, releasing a
+// region-allocated struct that owns a reference, assigning to an 'rc' variable
+// declared without an initial value, and passing an owning reference to a
+// parameter expecting a borrowed one.
+//
+// An allocation nested inside another one is absent for a different reason: it
+// works, and region-nested-alloc covers it.
 
 import stdio::*
 

--- a/test/cases/region/region-typecheck-coerce.cone
+++ b/test/cases/region/region-typecheck-coerce.cone
@@ -1,0 +1,28 @@
+// The region coercions that must stay refused.
+//
+// regionMatches allows a coercion only between identical regions or into the
+// borrow region. Everything else is a no-match, and the two that matter are the
+// reverse of what region-borrow-coerce establishes: a borrowed reference names
+// storage the callee does not own, so passing one where an owning reference is
+// wanted would hand a stack address to a parameter that will release it.
+//
+// This half could not be asserted while refMatches compared its regions in
+// reverse -- it compiled clean and ran, and there was no diagnostic to name.
+
+fn takesRc(r +rc-mut i32) i32 { *r }
+
+fn takesSo(r +so i32) i32 { *r }
+
+fn f() i32 {
+  mut local = 7i32
+
+  // A borrow may not stand in for an allocation, in either region
+  imm a = takesRc(&mut local)   //~ ErrorInvType
+  imm b = takesSo(&mut local)   //~ ErrorInvType
+
+  // Nor may one region's allocation stand in for another's
+  imm owned = +rc-mut 5
+  imm c = takesSo(owned)        //~ ErrorInvType
+
+  a
+}

--- a/test/cases/region/region-uninit-owning.cone
+++ b/test/cases/region/region-uninit-owning.cone
@@ -1,16 +1,14 @@
-// Defect: assigning to an 'rc' reference variable declared without an initial
-// value releases whatever the uninitialized storage happened to contain.
+// Assigning to an 'rc' reference variable that was declared without an initial
+// value stores into it without releasing what the uninitialized storage happened
+// to contain.
 //
-// genlStore in genllvm/genlexpr.c decrements the reference count of an lval's
-// previous value before storing the new one, which is right for a variable that
-// holds a reference and wrong for one that has never held anything. Flow
-// analysis knows the difference -- ir/exp/assign.c consults VarInitialized when
-// deciding whether the write is permitted -- but code generation does not ask.
-// The run dies on an illegal instruction inside the release path.
+// genlStore decrements an lval's previous reference count before storing the new
+// value, which is right for a variable that already holds a reference and wrong
+// for one that has never held anything. Flow analysis marks the first assignment
+// to a variable it knows is uninitialized, and genlStore skips the release there.
 //
-// 'so' has no such counter and genlStore skips it, so the same shape works for
-// the other region. This is why the success program always gives an 'rc'
-// variable its allocation in the declaration.
+// 'so' has no counter and genlStore skips it, so the same shape has always worked
+// for the other region.
 
 import stdio::*
 

--- a/test/cases/union/cases.toml
+++ b/test/cases/union/cases.toml
@@ -67,9 +67,9 @@ diagnostics = 6
 
 [scenario.union-typecheck-narrow]
 category = "reject"
-description = "Patterns narrowing to a type the matched value could never be"
+description = "Patterns narrowing to a type the matched value could never be, or to another region"
 tags = ["typecheck"]
-diagnostics = 3
+diagnostics = 4
 
 [scenario.union-typecheck-variant]
 category = "reject"

--- a/test/cases/union/union-typecheck-narrow.cone
+++ b/test/cases/union/union-typecheck-narrow.cone
@@ -47,3 +47,15 @@ fn matchNonUnion(n i32) i32 {
     else {0}
   }
 }
+
+// A pattern may not narrow across regions. The value is borrowed, so its variant
+// is borrowed too; asking for an owning reference would hand the match arm
+// storage that nothing gave it ownership of, and the two regions are laid out
+// differently besides -- an 'rc' allocation carries a count the borrow has no
+// room for. There is no recast between regions, so the regions must be the same.
+fn foreignRegion(s &Shape) i32 {
+  match s {
+    case imm c +rc-mut Circle {c.radius}   //~ ErrorInvType "won't downcast safely"
+    else {0}
+  }
+}

--- a/test/codes.toml
+++ b/test/codes.toml
@@ -81,6 +81,7 @@ ErrorNoCandidate = 1056
 ErrorAmbigCandidate = 1057
 ErrorOverloadUse = 1058
 ErrorBadFill = 1059
+ErrorFillCount = 1060
 WarnCode = 3000
 WarnName = 3001
 WarnIndent = 3002

--- a/test/codes.toml
+++ b/test/codes.toml
@@ -80,6 +80,7 @@ ErrorDupOverload = 1055
 ErrorNoCandidate = 1056
 ErrorAmbigCandidate = 1057
 ErrorOverloadUse = 1058
+ErrorBadFill = 1059
 WarnCode = 3000
 WarnName = 3001
 WarnIndent = 3002

--- a/workitems/Compiler defect backlog.md
+++ b/workitems/Compiler defect backlog.md
@@ -76,3 +76,21 @@ settle each in a minute.
 - **A parameterless macro name is not expanded** as a function's final statement,
   nor as the left operand of an operator. As a right operand and as an
   initializer it works.
+
+## Found while fixing [[Ownership memory safety]]
+
+Both were found by tracing something else, and neither belongs to ownership.
+
+- **An array holding owning references is never released.** `flowScopeDealias`
+  builds a scope's dealias list from variables whose *own* type is an owning
+  reference, and an array's type is an array. So every element leaks, however
+  the array was built. `region-fill-count` records this in passing, because
+  counting n holders for a fill is what makes the outcome a leak rather than a
+  use after free.
+- **`itypeIsGenericType` tests a tag nothing ever assigns.** It requires
+  `objfn->tag == GenericNameTag`, and `GenericNameTag` appears only in its own
+  declaration, two dispatch tables, and this test — it is never written to a
+  node. So the predicate is dead, and with it the `isTypeNode()` clause that
+  would let a generic instantiation count as a type. A written-out `Option[T]`
+  works only because the type parser instantiates it before anything asks. This
+  is why the fallible-allocation lowering fails; see [[Regions]].

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -11,8 +11,9 @@ the `region` group of the test suite. The evidence, with file and line, is under
 "Found while building the groups" in [[Add test suite]].
 
 **Four of the six are fixed**, and the two that remain are the two loud ones,
-left deliberately. Tracing the fourth uncovered two further defects in how flow
-analysis treats literals; both are fixed, and one open sibling is recorded.
+left deliberately. Tracing the fourth uncovered three further defects in how flow
+analysis treats literals; all three are fixed, and the code generation defect that
+keeps the last one from being asserted at run time is recorded.
 
 ## Status
 
@@ -31,9 +32,10 @@ Found while fixing the above:
 | --- | --- | --- |
 | A type literal's field values are never moved or copied | Silent corruption, and a use-after-move | **Fixed** — `typeLitFlow` |
 | A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
-| An array literal's elements are never moved or copied | Silent, same shape | **Open** — `move-flow-arraylit` |
+| An array literal's elements are never moved or copied | Silent, same shape | **Fixed** — `arrayLitFlow` |
+| An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Open** — `array-nonconst-literal` |
 
-The suite went from 111 scenarios / 98 passed / 14 xfail to **115 / 105 / 11**.
+The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 107 / 12**.
 
 ## The question this work item asks
 
@@ -131,15 +133,31 @@ wraps a value given by field name.
 Neither turned out to need a language decision. Both are the type's existing rule
 applied where it was not being applied.
 
+**An array literal was a leaf too**, and closing it took one decision rather than
+a design. The list form `[a, b]` gives every element a holder of its own, so each
+value is moved or copied exactly as a call's argument is. The fill form
+`[n; value]` makes n holders out of one value, and the two rules answer that
+differently: a move value has one owner and cannot have n, so a fill of one is
+**refused** — `ErrorBadFill`, unconditionally, because proving that n is 1 buys a
+construct nobody writes at the cost of a rule that is harder to state. A counted
+reference is repeated legitimately, so the count rises by n, or by n-1 from a
+temporary. That generalizes the non-fill case, which is exactly n = 1.
+
+The amount is a constant in the alias node, so a count known only at run time is
+refused as well rather than counted wrongly. **Rewriting a fill into a loop before
+generation is the general answer**, and it is recorded in [[Types. Array]] along
+with the semantic question it raises.
+
 ## What remains
 
-**An array literal has the same gap** — `ArrayLitTag` is still a leaf, so
-`[hd, Handle[8]]` does not deactivate `hd`. It is **not** the same fix, which is
-why it is recorded rather than made: an array literal has a second form, the fill
-`[n; value]`, which repeats one expression across n elements. A move value cannot
-be moved into n slots, and a counted reference would need n added rather than one.
-**What a fill does to a move or counted value is undecided**, and that is the
-blocker. `move-flow-arraylit` pins the list form, which is not in doubt.
+**The count a fill asks for cannot be asserted against generated code**, and the
+reason is not in this group: `genlExpr` builds an array literal with
+`LLVMConstArray`, so an element that is the result of an instruction — and an
+allocation always is — produces a constant array with instruction operands, and
+the module fails verification. It is true of an `i32` as much as of a reference,
+which is why nothing had noticed: the `array` group only ever writes constant
+elements. `array-nonconst-literal` records the cause and `region-fill-count` the
+consequence.
 
 **The two loud failures stay open deliberately.** Neither can be mistaken for
 working code — nested allocation fails module verification at compile time, and

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -10,10 +10,8 @@ Six defects in how owning references are generated and coerced, found by buildin
 the `region` group of the test suite. The evidence, with file and line, is under
 "Found while building the groups" in [[Add test suite]].
 
-**Four of the six are fixed**, and the two that remain are the two loud ones,
-left deliberately. Tracing the fourth uncovered three further defects in how flow
-analysis treats literals; all three are fixed, and the code generation defect that
-keeps the last one from being asserted at run time is recorded.
+**Five of the six are fixed.** Only fallible allocation remains of the original
+list. Tracing them uncovered four further defects, three of them fixed.
 
 ## Status
 
@@ -23,8 +21,8 @@ keeps the last one from being asserted at run time is recorded.
 | A moved `+so` reference double-frees | Silent corruption | **Fixed** — `flow.c` |
 | First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c` + `genlexpr.c` |
 | A struct's `rc` owning field corrupts the heap on release | Silent corruption | **Fixed** — `genlalloc.c:62` |
-| A nested allocation | Loud, at compile time | **Open, deliberately** — `region-nested-alloc` |
-| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open, deliberately** — [[Diagnose instead of crash]] |
+| A nested allocation fails module verification | Loud, at compile time | **Fixed** — `genlallocref`'s phi |
+| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open** — see below |
 
 Found while fixing the above:
 
@@ -34,8 +32,16 @@ Found while fixing the above:
 | A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
 | An array literal's elements are never moved or copied | Silent, same shape | **Fixed** — `arrayLitFlow` |
 | An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Open** — `array-nonconst-literal` |
+| Every array-reference allocation takes the fill path | **Silent, wrong data** | **Open** — `genlalloc.c:227` |
 
-The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 107 / 12**.
+The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 108 / 11**.
+
+The last of those is the worst-behaved thing on this page and is one token:
+`((ArrayNode*)allocatenode->vtexp)->dimens > 0` tests a `Nodes*` pointer, which is
+never null there, instead of `->dimens->used > 0` as the same function does sixty
+lines earlier. So `+[]rc-mut [11i32, 22i32, 33i32]` compiles, runs, and fills the
+array with three copies of `11`. It belongs to array allocation rather than to
+ownership, but it is recorded here because this is where it was found.
 
 ## The question this work item asks
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -8,8 +8,24 @@
 
 Six defects in how owning references are generated and coerced, found by building
 the `region` group of the test suite. The evidence, with file and line, is under
-"Found while building the groups" in [[Add test suite]]. It is recorded here
-because it is expensive to rediscover, not because it is urgent to repair.
+"Found while building the groups" in [[Add test suite]].
+
+**Four are now fixed by stopgaps.** Two remain, plus one more the stopgap work
+uncovered. This item stays open for those three.
+
+## Status
+
+| Defect | How it failed | State |
+| --- | --- | --- |
+| Region coercion reads backwards | Silent unsoundness | **Fixed** — `reference.c:181`, `:226`, `arrayref.c:82` |
+| A moved `+so` reference double-frees | Silent corruption | **Fixed** — `flow.c:205` |
+| First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c:170` + `genlexpr.c:819` |
+| A struct's `rc` owning field corrupts the heap on release | Silent corruption | **Fixed** — `genlalloc.c:62` |
+| A struct's `+so` owning field double-frees | Silent corruption | **Open** — `region-owning-field-so` |
+| A nested allocation | Loud, at compile time | **Open, deliberately** — `region-nested-alloc` |
+| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open, deliberately** — [[Diagnose instead of crash]] |
+
+The suite went from 111 scenarios / 98 passed / 14 xfail to **114 / 103 / 12**.
 
 ## The question this work item asks
 
@@ -20,257 +36,97 @@ and a thorough one risks entrenching decisions the redesign wants to make freshl
 The question is: **which of these cost time before the redesign lands, and what
 is the cheapest thing that stops them costing it?**
 
-That splits the six cleanly, because they differ in how they fail rather than in
-how deep they are.
+That splits the six by how they fail rather than by how deep they are. The three
+silent-corruption defects and the soundness hole earn a stopgap, because a program
+that compiles, runs and corrupts the heap can burn an afternoon with nothing
+pointing at the compiler. The two loud ones do not: you find out at once, so
+fixing them buys convenience rather than safety, and the redesign revisits both
+paths anyway.
 
-## Triage
+## What measuring the stopgaps showed
 
-### Silent memory corruption — worth a stopgap
+Each candidate was built, run against the whole suite, and reverted before any of
+it was recommended. Three results are worth carrying into the redesign.
 
-These produce wrong runtime behavior with no diagnostic and no crash at the point
-of the mistake. They are the only ones that can burn an afternoon: a program
-compiles, runs, and corrupts the heap, and nothing points at the compiler.
+**The three silent-corruption defects were not one fix.** The original triage
+guessed they shared a cause. Each turned out to be independent — fixed alone, with
+zero regressions — and two landed in a different phase than predicted:
 
-| Defect | Cause | Scenario |
-| --- | --- | --- |
-| A moved `+so` reference double-frees | `genlDealiasNodes` frees every variable whose type is an owning reference, with no notion of one whose value was moved out | `region-so-move` |
-| A first assignment to an uninitialized `rc` variable releases garbage | `genlStore` dealiases the lval's previous value without consulting `VarInitialized` | `region-uninit-owning` |
-| A region-allocated struct owning a reference corrupts the heap on release | `genlDealiasFlds` reaches the field with a struct GEP and hands that **address** to `genlRcCounter`/`genlDealiasOwn`, which want the reference the field **holds** | `region-owning-field` |
+- **The `+so` move fix is in flow analysis, not code generation.** The dealias
+  list is *built* by `flowScopeDealias` (`ir/flow.c:198`) and merely executed by
+  `genlDealiasNodes`. Flow holds the move state at exactly that point and never
+  read it.
+- **The uninitialized-store fix could not read flow state from codegen.**
+  `flowtempflags` is a running summary, not a per-program-point record; by code
+  generation it says only "was initialized somewhere". Flow now marks the
+  assignment site itself.
+- **The owning-field fix was the plain wrong-argument bug it looked like.** The
+  predicted complication — that fixing the GEP would turn a leak into a release
+  that then had to be made correct — did not occur.
 
-**These three are probably one fix, not three**, and establishing whether that is
-true is the first thing worth doing. The first two are both *codegen not asking
-what flow analysis already worked out* — flow correctly tracks deactivation and
-correctly identifies which owning references are move types, and the dealias path
-simply does not read it. The third looks like a plain wrong-argument bug, but
-fixing the GEP turns a leak into a release, and that release then has to be
-correct, which lands it back in the same territory.
+**There is no durable flow record for later phases.** `VarDclNode.flowflags`, the
+*permanent* flow word (`ir/stmt/vardcl.h:20`), is zeroed in two places and never
+set or read. `VarFlowInfo.flags` (`ir/flow.c:159`), commented "the preserved flow
+flags", is likewise dead. That absence, rather than any single bug, is the
+structural reason this class keeps recurring, and it is the thing the redesign
+should fix properly.
 
-A caveat that matters for scoping: a **stack** struct with an owning field is
-currently safe only because its fields are never released at all. They leak. So
-the third fix cannot be evaluated on its own.
+**The coercion swap cost nothing, and it is three lines rather than one.** The
+same reversed call sits at `reference.c:226` and `arrayref.c:82`; fixing only
+`refMatches` would have left virtual references and ref-to-arrayref coercion
+backwards. `ir/exp/cast.c:176` is a fourth call in the same order and was left
+alone deliberately — it asks a different question (`is` downcasting), where the
+regions are normally identical so `EqMatch` fires first. **Deciding what region
+downcasting means belongs to the redesign.**
 
-### Silent unsoundness — measure, then decide
+The one honest limit on "zero regressions": the repository contains no Cone source
+outside `test/cases/`, so the suite is the whole measurable corpus.
 
-`refMatches` calls `regionMatches(from->region, to->region)`, arguments swapped
-against the parameter names. One direction rejects an owning reference where a
-borrowed one is wanted, which is obstructive and is pinned by
-`region-borrow-coerce` as an `xfail`. The other **silently accepts a borrowed
-reference where an owning one is wanted**, handing a stack address to a parameter
-typed `+rc-mut`.
+### Known cost of the stopgaps
 
-Swapping the arguments back is one line. What it costs is that programs which
-compile today will stop, and some may be in `test/cases/`. **Measure that before
-deciding** — if the blast radius is small, this is the cheapest real win on the
-page, because it removes a trap that fails silently. If it is large, it is
-redesign work rather than stopgap work, since what coercions exist between
-regions is exactly what a redesign would settle.
+- The `VarMoved` skip is **path-insensitive**. The flag is the state at scope exit,
+  so a value moved on only one branch is skipped on all of them — that leaks
+  rather than double-frees. Making it precise means per-program-point flow state,
+  which is redesign work.
+- `FlagFirstAssign` adds a flag bit to the IR. It is the most entrenching of the
+  four and the first to reconsider once the redesign starts.
 
-Note the suite cannot hold the dangerous half. There is no diagnostic to assert
-against until the compiler rejects the coercion, so a scenario for it can only be
-written after the fix.
+## What remains
 
-### Loud failures — leave them
+**A `+so` owning field still double-frees**, and the cause is not in this group: a
+type literal's field initializers do not apply move semantics, so naming a
+variable in a literal never deactivates it. Passing the same value as a call
+argument does deactivate it. That gap is independently a **use-after-move hole** —
+reading the moved-from variable afterwards compiles clean — and it is recorded as
+`move-flow-literal` in the `move` group, with `region-owning-field-so` recording
+the consequence here.
 
-| Defect | How it fails |
-| --- | --- |
-| A nested allocation | LLVM module verification fails, at compile time |
-| Fallible allocation `?+rc-mut v` | Access violation, immediately |
+**Closing it is a language decision, not a codegen fix**: it settles whether a
+literal moves or copies its initializers. It is handed to the redesign rather than
+patched.
 
-Neither is silent and neither can be mistaken for working code, so neither wastes
-debugging time — you find out at once. Fixing them buys convenience, not safety,
-and the redesign will revisit both paths anyway. `region-nested-alloc` is pinned
-as an `xfail`; the fallible-allocation crash is cross-listed to
-[[Diagnose instead of crash]], which is where the systematic version of that
-problem lives.
-
-## Recommendation, from measurement rather than survey
-
-Each stopgap below was built and run before being recommended. Method: build the
-compiler, confirm the baseline (111 scenarios, 98 passed, 14 expected failures),
-apply one candidate fix, rebuild, run the whole suite, record the result, revert.
-Then apply all of them together and run again. Everything was reverted afterwards
-— nothing under `src/` changed. The numbers below are observed, not projected.
-
-### The triage's grouping claim does not hold: three defects, three fixes
-
-The work item proposes the three silent-corruption defects "are probably one fix,
-not three". They are not. Each was fixed **in isolation**, and each fixed its own
-scenario with **zero regressions across the full suite**.
-
-| Defect | Where the fix goes | Size | Result in isolation |
-| --- | --- | --- | --- |
-| `region-so-move` | `ir/flow.c:205`, in `flowScopeDealias` | 2 lines | XPASS, 98 pass, no regressions |
-| `region-uninit-owning` | `ir/exp/assign.c:168` + `genllvm/genlexpr.c:818` + a flag bit | ~5 lines, 3 files | XPASS, 98 pass, no regressions |
-| `region-owning-field` | `genllvm/genlalloc.c:62`, add the load | 2 lines | XPASS, 98 pass, no regressions |
-
-The reasoning that grouped them is what misleads, and it is worth correcting
-because it points at the wrong subsystem:
-
-- **`region-so-move` is not codegen ignoring flow analysis.** The dealias list is
-  *built by flow analysis* — `flowScopeDealias` (`ir/flow.c:198`), called from
-  `blockFlow` (`ir/exp/block.c:291-321`), walks the scope's variables and records
-  which ones to release on `BreakRetNode->dealias`. `genlDealiasNodes` only
-  executes that list. Flow has `flowtempflags` in its hand at exactly that point
-  and never reads it. The fix is `continue` on `VarMoved`, in flow, not codegen.
-- **`region-uninit-owning` genuinely is codegen not asking** — but it cannot be
-  fixed by reading `flowtempflags` from `genlStore`, because that word is a
-  *running* state during the walk, not a per-program-point record. By codegen it
-  says only "was initialized somewhere". Flow has to record the fact at the
-  assignment site instead; `ir/exp/assign.c:162` already computes exactly this
-  condition and then throws it away.
-- **`region-owning-field` is the plain wrong-argument bug it looks like.** The
-  predicted complication — that fixing the GEP "turns a leak into a release, and
-  that release then has to be correct" — did not occur. Adding the load fixed the
-  scenario and `region-success` still passed unchanged.
-
-Worth recording for the redesign: `VarDclNode.flowflags`, the *permanent* flow
-word (`ir/stmt/vardcl.h:20`), is zeroed in two places and never set or read
-anywhere. `VarFlowInfo.flags` in `ir/flow.c:159`, commented "the preserved flow
-flags", is likewise set to 0 and never used. **There is no durable flow record for
-later phases to consult.** That absence, not any individual bug, is the structural
-reason this class of defect keeps recurring.
-
-### The coercion swap costs nothing — measured, and it is the best buy
-
-Swapping `regionMatches(from->region, to->region)` to `(to->region, from->region)`
-at `ir/types/reference.c:181`: **the entire suite is unchanged except that
-`region-borrow-coerce` flips to XPASS.** No other scenario moved.
-
-Two things the survey missed:
-
-- **It is three lines, not one.** The same reversed call appears at
-  `ir/types/reference.c:226` (`refvirtMatchesRef`) and `ir/types/arrayref.c:82`
-  (`arrayRefMatchesRef`). Fixing only `refMatches` leaves virtual references and
-  ref-to-arrayref coercion still backwards. Swapping all three: **still zero
-  regressions.** Do all three or the hole stays open on two paths.
-- **Leave `ir/exp/cast.c:176` alone.** It is a fourth call in the same argument
-  order, but it asks a different question (`is` downcasting), where the regions
-  are normally identical so `EqMatch` fires first. Swapping it blind would be
-  guessing. Flag it for the redesign.
-
-Honest limit on "blast radius": the repository contains **no Cone source outside
-`test/cases/`** — 110 files, all of them the suite. `conesite/` ships HTML and a
-prebuilt `.wasm`, not compilable sources. So the suite *is* the measurable corpus,
-and "zero regressions" means zero across everything there is to measure. The
-direction the swap newly rejects is precisely the unsound one, so unmeasured
-breakage would have to be code that was already relying on the hole.
-
-### Confidence without a test: the problem dissolves on contact
-
-The work item says the dangerous half "cannot have a scenario until it is fixed".
-True, and the fix supplies one immediately. Probe — a borrowed reference passed to
-a `+rc-mut` parameter:
-
-```
-fn takesOwning(r +rc-mut i32) i32 { *r }
-fn f() i32 {
-  mut local = 7i32
-  takesOwning(&mut local)     // hands a stack address to an owning parameter
-}
-```
-
-Pristine compiler: **compiles clean, exit 0.** With the swap: `Error 1013:
-Expression's type does not match declared parameter`. So there is a real
-diagnostic to assert the moment the swap lands. The answer to "how would you gain
-confidence without a test" is: don't — fix it first, then pin it, in that order,
-in the same change. The scenario is about ten lines in a `reject` case.
-
-### A seventh defect, unrecorded, that limits the third stopgap
-
-`region-owning-field` pins a struct with an **`rc`** owning field. A struct with a
-**`+so`** owning field still corrupts the heap — with the GEP fix applied *and* on
-the pristine compiler, identically (`0xC0000374`, heap corruption):
-
-```
-struct HeldSo { r +so i32 }
-fn f() {
-  imm inner = +so 5
-  imm outer = +so HeldSo[r: inner]     // 'inner' is never deactivated
-  ...
-}
-```
-
-The cause is not in `region` at all: **a type literal's field initializers do not
-apply move semantics.** Passing a `@move` value as a call argument correctly
-raises `ErrorMove` (1048); placing the same value in a struct literal raises
-nothing, and the source variable stays live and stays on the dealias list. Hence
-the double free. It is independently a **use-after-move hole** — reading the
-moved-from variable afterwards compiles clean.
-
-This is not recorded in this item or in [[Add test suite]]'s survey, and the
-`move` group covers only moving *out of* an aggregate (`move-flow-aggregate`),
-never *into* one. It belongs to `move`, and it should be **handed to the redesign
-rather than patched**: making literals move changes which programs are legal,
-which is a language decision, not a stopgap.
-
-The consequence for scoping: the GEP fix is worth doing and covers the `rc` half,
-but it is a **partial** fix and should be labelled as one.
-
-### What to do
-
-Land as one small, obviously-temporary change, ~10 lines total:
-
-1. **Swap the region arguments at all three sites** (`reference.c:181` and `:226`,
-   `arrayref.c:82`). Silent unsoundness, measured cost zero, and it converts an
-   unassertable hole into an assertable one. Highest value on the page.
-2. **Skip moved variables in `flowScopeDealias`.** Silent double free, 2 lines.
-3. **Load the field in `genlDealiasFlds`.** Silent heap corruption, 2 lines,
-   `rc` half only.
-4. **Record first-assignment in flow and read it in `genlStore`.** Silent release
-   of garbage. The most invasive of the four — it adds a flag bit to the IR — and
-   the first to reconsider if the redesign starts soon.
-
-All four together: **98 passed, 4 XPASS, no regressions.**
-
-Where a hack would be worse than the defect:
-
-- **Do not make the `VarMoved` skip path-sensitive.** The flag is a running state,
-  so a variable moved on only one branch is skipped on every branch — that leaks.
-  A leak is strictly better than a double free, and making it precise means
-  per-program-point flow state, which is redesign work.
-- **Do not fix the struct-literal move gap** as a stopgap (above).
-- **Do not touch `cast.c:176`** without deciding what region downcasting means.
-- **Leave the two loud failures.** Confirmed still loud: nested allocation fails
-  module verification at compile time, and `?+rc-mut v` dies immediately with an
-  access violation (`0xC0000005`). Neither can be mistaken for working code.
-
-### Scenarios this implies — to write with the fix, not before
-
-- Drop `xfail` from `region-so-move`, `region-uninit-owning`, `region-owning-field`
-  and `region-borrow-coerce`; they become ordinary passing scenarios.
-- **New `reject` scenario** for the dangerous coercion half, now that it has a
-  diagnostic. It is `region`'s, alongside the other type-check scenarios.
-- **New `xfail`** for the `+so` owning field, recording the half the GEP fix does
-  not cover.
-- **New `xfail` in `move`** for the struct-literal move gap, with the
-  use-after-move probe — that is where the defect actually lives.
-
-### What this says about the five xfails
-
-The question of whether they survive the redesign largely evaporates: **four of
-the five would be retired by this change itself**, leaving only
-`region-nested-alloc`. And they behaved exactly as the item argues they would —
-each flipped to XPASS and failed the suite the moment its defect was fixed, which
-is how every measurement above was confirmed. They earned their keep this session.
-
-`region-success` is the asset the item says it is, and it proved it here: it
-passed unchanged under all four prototypes, which is what made "no regressions"
-a statement about behavior rather than about compilation.
+**The two loud failures stay open deliberately.** Neither can be mistaken for
+working code — nested allocation fails module verification at compile time, and
+`?+rc-mut v` dies immediately with an access violation.
 
 ## What the scenarios are worth, given a redesign is coming
 
-Five `xfail` scenarios sit in `test/cases/region/`. They cost nothing to keep and
-they are worth keeping even though the surface may change, for two reasons: each
-is a reduced, executable statement of a defect that would otherwise have to be
-rediscovered from prose, and each will flip to XPASS and fail the suite the moment
-the behavior changes — including as a side effect of the redesign, which is
-exactly when you want to be told.
+The `xfail` scenarios cost nothing to keep and are worth keeping even though the
+surface may change: each is a reduced, executable statement of a defect that would
+otherwise have to be rediscovered from prose, and each flips to XPASS and fails the
+suite the moment the behavior changes — including as a side effect of the redesign,
+which is exactly when you want to be told.
 
-If the redesign changes the spelling of regions, they will need rewriting rather
-than deleting. `region-success` is the one to protect: 37 established facts about
-what allocation, reference counting and release actually do today, which is the
-closest thing there is to a specification of the current behavior for the
-redesign to diff against.
+That is not a prediction any more. Four of the five did precisely this during the
+stopgap work, and each flip is how the corresponding fix was confirmed.
+
+If the redesign changes the spelling of regions, the remaining scenarios will need
+rewriting rather than deleting. `region-success` is the one to protect: 37
+established facts about what allocation, reference counting and release actually
+do today, which is the closest thing there is to a specification of current
+behavior for the redesign to diff against. It passed unchanged under every
+prototype, which is what made "no regressions" a claim about behavior rather than
+about compilation.
 
 ## Not in scope
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -1,71 +1,102 @@
 # Ownership memory safety
 
-Six defects in how owning references are generated and coerced. Each is a way the
-compiler emits code that corrupts memory, or accepts a program it should reject.
-They were found by building the `region` group of the test suite; the evidence,
-with file and line, is under "Found while building the groups" in
-[[Add test suite]].
+> **These are defects in provisional code.** Regions are only partly built and
+> were never robustly designed; a redesign carrying substantially new ideas is
+> intended, and getting that design right is the priority. Nothing here should be
+> read as an argument for hardening the current implementation. Anything fixed
+> before the redesign is a stopgap, and should look like one.
 
-This is the most serious body of work that survey produced, and it is separated
-from the other defects for one reason: **these are miscompiles.** A program that
-fails to compile wastes an afternoon. A program that compiles, runs, and
-double-frees wastes a week, and does it in someone else's code.
+Six defects in how owning references are generated and coerced, found by building
+the `region` group of the test suite. The evidence, with file and line, is under
+"Found while building the groups" in [[Add test suite]]. It is recorded here
+because it is expensive to rediscover, not because it is urgent to repair.
 
-## The soundness hole comes first
+## The question this work item asks
 
-`refMatches` calls `regionMatches(from->region, to->region)`. The arguments are
-swapped against the parameter names, and the effect runs both ways:
+Not *how do we fix these properly*. The implementation they live in is going to
+be replaced, so a careful fix is effort spent on code with a known expiry date,
+and a thorough one risks entrenching decisions the redesign wants to make freshly.
 
-- An **owning reference is rejected** where a borrowed one is wanted. Merely
-  obstructive, and pinned by `test/cases/region/region-borrow-coerce.cone` as an
-  `xfail`, so fixing it will announce itself.
-- A **borrowed reference is silently accepted** where an owning one is wanted. A
-  stack address reaches a parameter typed `+rc-mut`; it compiles, it runs, and
-  whatever the callee does with it — retain, release, store — operates on a
-  pointer the region does not own.
+The question is: **which of these cost time before the redesign lands, and what
+is the cheapest thing that stops them costing it?**
 
-The second has no diagnostic to assert against, so **the test suite cannot hold
-it**. That is worth stating plainly: fixing this defect is not something a test
-run will confirm, and a scenario for it can only be written once the compiler
-rejects the coercion.
+That splits the six cleanly, because they differ in how they fail rather than in
+how deep they are.
 
-Swapping the arguments back is a one-line change. What it costs is that programs
-which currently compile will stop, and some of those will be in `test/cases/` —
-this work item exists because that consequence needs deciding, not because the
-line is hard to find.
+## Triage
 
-## The four codegen defects
+### Silent memory corruption — worth a stopgap
 
-Each has an `xfail` scenario in `test/cases/region/` that will fail the suite the
-day it is fixed, so none of them can be fixed quietly.
+These produce wrong runtime behavior with no diagnostic and no crash at the point
+of the mistake. They are the only ones that can burn an afternoon: a program
+compiles, runs, and corrupts the heap, and nothing points at the compiler.
 
 | Defect | Cause | Scenario |
 | --- | --- | --- |
-| A moved `+so` reference double-frees | `genlDealiasNodes` frees every variable whose type is an owning reference, with no notion of one whose value was moved out. Flow analysis knows; codegen does not ask | `region-so-move` |
+| A moved `+so` reference double-frees | `genlDealiasNodes` frees every variable whose type is an owning reference, with no notion of one whose value was moved out | `region-so-move` |
 | A first assignment to an uninitialized `rc` variable releases garbage | `genlStore` dealiases the lval's previous value without consulting `VarInitialized` | `region-uninit-owning` |
 | A region-allocated struct owning a reference corrupts the heap on release | `genlDealiasFlds` reaches the field with a struct GEP and hands that **address** to `genlRcCounter`/`genlDealiasOwn`, which want the reference the field **holds** | `region-owning-field` |
-| A nested allocation fails LLVM module verification | | `region-nested-alloc` |
 
-A fifth, fallible allocation `?+rc-mut v`, dies with an access violation and so
-belongs to [[Diagnose instead of crash]] rather than here.
+**These three are probably one fix, not three**, and establishing whether that is
+true is the first thing worth doing. The first two are both *codegen not asking
+what flow analysis already worked out* — flow correctly tracks deactivation and
+correctly identifies which owning references are move types, and the dealias path
+simply does not read it. The third looks like a plain wrong-argument bug, but
+fixing the GEP turns a leak into a release, and that release then has to be
+correct, which lands it back in the same territory.
 
-The first two share a shape worth naming: **codegen is not consulting what flow
-analysis already worked out.** `move` established that flow analysis correctly
-tracks deactivation, and `region-flow` establishes that it correctly identifies
-which owning references are move types. The information exists at the point
-`genlDealiasNodes` runs; it is simply not read. Whether the fix is to consult the
-flags or to have flow analysis annotate the nodes it has decided about is the
-design question.
+A caveat that matters for scoping: a **stack** struct with an owning field is
+currently safe only because its fields are never released at all. They leak. So
+the third fix cannot be evaluated on its own.
 
-The third is a plain bug with no decision attached, and is the cheapest of the
-four.
+### Silent unsoundness — measure, then decide
 
-## Why a stack struct with an owning field is not also broken
+`refMatches` calls `regionMatches(from->region, to->region)`, arguments swapped
+against the parameter names. One direction rejects an owning reference where a
+borrowed one is wanted, which is obstructive and is pinned by
+`region-borrow-coerce` as an `xfail`. The other **silently accepts a borrowed
+reference where an owning one is wanted**, handing a stack address to a parameter
+typed `+rc-mut`.
 
-It leaks instead. Its fields are never released at all, which is why the defect
-only shows up for region-allocated structs. Fixing the GEP will therefore turn a
-leak into a release, and that release has to be correct — the two cannot be
-separated.
+Swapping the arguments back is one line. What it costs is that programs which
+compile today will stop, and some may be in `test/cases/`. **Measure that before
+deciding** — if the blast radius is small, this is the cheapest real win on the
+page, because it removes a trap that fails silently. If it is large, it is
+redesign work rather than stopgap work, since what coercions exist between
+regions is exactly what a redesign would settle.
+
+Note the suite cannot hold the dangerous half. There is no diagnostic to assert
+against until the compiler rejects the coercion, so a scenario for it can only be
+written after the fix.
+
+### Loud failures — leave them
+
+| Defect | How it fails |
+| --- | --- |
+| A nested allocation | LLVM module verification fails, at compile time |
+| Fallible allocation `?+rc-mut v` | Access violation, immediately |
+
+Neither is silent and neither can be mistaken for working code, so neither wastes
+debugging time — you find out at once. Fixing them buys convenience, not safety,
+and the redesign will revisit both paths anyway. `region-nested-alloc` is pinned
+as an `xfail`; the fallible-allocation crash is cross-listed to
+[[Diagnose instead of crash]], which is where the systematic version of that
+problem lives.
+
+## What the scenarios are worth, given a redesign is coming
+
+Five `xfail` scenarios sit in `test/cases/region/`. They cost nothing to keep and
+they are worth keeping even though the surface may change, for two reasons: each
+is a reduced, executable statement of a defect that would otherwise have to be
+rediscovered from prose, and each will flip to XPASS and fail the suite the moment
+the behavior changes — including as a side effect of the redesign, which is
+exactly when you want to be told.
+
+If the redesign changes the spelling of regions, they will need rewriting rather
+than deleting. `region-success` is the one to protect: 37 established facts about
+what allocation, reference counting and release actually do today, which is the
+closest thing there is to a specification of the current behavior for the
+redesign to diff against.
 
 ## Not in scope
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -32,16 +32,18 @@ Found while fixing the above:
 | A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
 | An array literal's elements are never moved or copied | Silent, same shape | **Fixed** — `arrayLitFlow` |
 | An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Open** — `array-nonconst-literal` |
-| Every array-reference allocation takes the fill path | **Silent, wrong data** | **Open** — `genlalloc.c:227` |
+| Every array-reference allocation takes the fill path | **Silent, wrong data** | **Fixed** — `genlalloc.c:227` |
 
 The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 108 / 11**.
 
-The last of those is the worst-behaved thing on this page and is one token:
-`((ArrayNode*)allocatenode->vtexp)->dimens > 0` tests a `Nodes*` pointer, which is
-never null there, instead of `->dimens->used > 0` as the same function does sixty
-lines earlier. So `+[]rc-mut [11i32, 22i32, 33i32]` compiles, runs, and fills the
+That last one was the worst-behaved thing on this page and was one token:
+`((ArrayNode*)allocatenode->vtexp)->dimens > 0` tested a `Nodes*` pointer, which is
+never null there, rather than `->dimens->used > 0` as the same function does sixty
+lines earlier. So `+[]rc-mut [11i32, 22i32, 33i32]` compiled, ran, and filled the
 array with three copies of `11`. It belongs to array allocation rather than to
-ownership, but it is recorded here because this is where it was found.
+ownership and is recorded here only because this is where it was found;
+`collection-success` now allocates a slice as well as borrowing one, which is the
+case that fails without the fix.
 
 ## The question this work item asks
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -22,7 +22,7 @@ list. Tracing them uncovered four further defects, three of them fixed.
 | First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c` + `genlexpr.c` |
 | A struct's `rc` owning field corrupts the heap on release | Silent corruption | **Fixed** — `genlalloc.c:62` |
 | A nested allocation fails module verification | Loud, at compile time | **Fixed** — `genlallocref`'s phi |
-| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open** — see below |
+| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open** — needs a lowering decision, see below |
 
 Found while fixing the above:
 
@@ -31,10 +31,14 @@ Found while fixing the above:
 | A type literal's field values are never moved or copied | Silent corruption, and a use-after-move | **Fixed** — `typeLitFlow` |
 | A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
 | An array literal's elements are never moved or copied | Silent, same shape | **Fixed** — `arrayLitFlow` |
-| An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Open** — `array-nonconst-literal` |
+| An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Fixed** — `genlExpr` builds with insertvalue |
 | Every array-reference allocation takes the fill path | **Silent, wrong data** | **Fixed** — `genlalloc.c:227` |
 
-The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 108 / 11**.
+The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 110 / 9**, and
+the `region` group now carries no expected failures at all. The fill amount is
+asserted rather than merely emitted: `region-fill-count` reads the counter
+adjustment out of the generated IR, `add i64 %5, 12` from an lvalue fill and
+`add i64 %5, 11` from a temporary, which is the n / n-1 rule stated in numbers.
 
 That last one was the worst-behaved thing on this page and was one token:
 `((ArrayNode*)allocatenode->vtexp)->dimens > 0` tested a `Nodes*` pointer, which is
@@ -167,9 +171,43 @@ which is why nothing had noticed: the `array` group only ever writes constant
 elements. `array-nonconst-literal` records the cause and `region-fill-count` the
 consequence.
 
-**The two loud failures stay open deliberately.** Neither can be mistaken for
-working code — nested allocation fails module verification at compile time, and
-`?+rc-mut v` dies immediately with an access violation.
+## Fallible allocation, and why it is not a repair
+
+The semantics are settled and code generation already implements them. A plain
+allocation traps when the allocator returns null; `?` sets `FlagQues`, which
+suppresses the trap so the null reaches the program. `Option[&T]` needs no tag or
+wrapper because `genltype.c:174` collapses a two-variant union whose other variant
+holds one pointer into a bare pointer — so "either a null or a real reference" is
+the literal runtime representation, and `genlexpr` specialises both testing it and
+constructing it. **None of this is redesign-blocked.** How a region signals failure
+is already fixed: `_alloc` returns `*u8` and the null check is in `genlallocref`.
+
+What is broken is the front-end lowering, and it is structural rather than a slip:
+
+- **The allocate node's `vtype` ends up an expression.** Measured: for `+rc-mut 42`
+  it is `RefTag`; for `?+rc-mut 42` it stays `FnCallTag` — an un-instantiated
+  `Option[...]` in a type slot, which everything calling `itypeGetTypeDcl` then
+  walks as if it were a type.
+- **`itypeIsGenericType` is dead.** It is the only thing that can make
+  `isTypeNode()` true for a generic instantiation, and it tests for
+  `GenericNameTag`, which **nothing in the compiler ever assigns**. A written-out
+  `Option[T]` works only because the type parser instantiates it before anyone
+  asks the predicate; the `?` path has no such step.
+- **The lowering builds a cycle.** Name resolution points the allocate node's
+  `vtype` at the Option call whose `args[0]` *is that allocate node*, and type
+  check later patches it to a `RefNode` whose lex parent is the same allocate
+  node. Instantiating a generic across that recurses, which is why `?+rc-mut`
+  faults while `?+so` hangs.
+
+Substituting `itypeTypeCheck` for `inodeTypeCheckAny` gets `vtype` to a type node
+and still fails, so this is not a one-line repair. **The decision it needs** is
+where `?` lowers: instantiating `Option[T]` as a real type during name resolution,
+so the allocate node's `vtype` is a type from the outset, rather than an expression
+patched mid-type-check.
+
+Note the suite cannot hold this one either way. `?+so` hangs, and a scenario whose
+assertion is "this takes twenty seconds" asserts nothing — see "What cannot be a
+scenario at all" in [[Test Suite]].
 
 ## What the scenarios are worth, given a redesign is coming
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -83,6 +83,180 @@ as an `xfail`; the fallible-allocation crash is cross-listed to
 [[Diagnose instead of crash]], which is where the systematic version of that
 problem lives.
 
+## Recommendation, from measurement rather than survey
+
+Each stopgap below was built and run before being recommended. Method: build the
+compiler, confirm the baseline (111 scenarios, 98 passed, 14 expected failures),
+apply one candidate fix, rebuild, run the whole suite, record the result, revert.
+Then apply all of them together and run again. Everything was reverted afterwards
+— nothing under `src/` changed. The numbers below are observed, not projected.
+
+### The triage's grouping claim does not hold: three defects, three fixes
+
+The work item proposes the three silent-corruption defects "are probably one fix,
+not three". They are not. Each was fixed **in isolation**, and each fixed its own
+scenario with **zero regressions across the full suite**.
+
+| Defect | Where the fix goes | Size | Result in isolation |
+| --- | --- | --- | --- |
+| `region-so-move` | `ir/flow.c:205`, in `flowScopeDealias` | 2 lines | XPASS, 98 pass, no regressions |
+| `region-uninit-owning` | `ir/exp/assign.c:168` + `genllvm/genlexpr.c:818` + a flag bit | ~5 lines, 3 files | XPASS, 98 pass, no regressions |
+| `region-owning-field` | `genllvm/genlalloc.c:62`, add the load | 2 lines | XPASS, 98 pass, no regressions |
+
+The reasoning that grouped them is what misleads, and it is worth correcting
+because it points at the wrong subsystem:
+
+- **`region-so-move` is not codegen ignoring flow analysis.** The dealias list is
+  *built by flow analysis* — `flowScopeDealias` (`ir/flow.c:198`), called from
+  `blockFlow` (`ir/exp/block.c:291-321`), walks the scope's variables and records
+  which ones to release on `BreakRetNode->dealias`. `genlDealiasNodes` only
+  executes that list. Flow has `flowtempflags` in its hand at exactly that point
+  and never reads it. The fix is `continue` on `VarMoved`, in flow, not codegen.
+- **`region-uninit-owning` genuinely is codegen not asking** — but it cannot be
+  fixed by reading `flowtempflags` from `genlStore`, because that word is a
+  *running* state during the walk, not a per-program-point record. By codegen it
+  says only "was initialized somewhere". Flow has to record the fact at the
+  assignment site instead; `ir/exp/assign.c:162` already computes exactly this
+  condition and then throws it away.
+- **`region-owning-field` is the plain wrong-argument bug it looks like.** The
+  predicted complication — that fixing the GEP "turns a leak into a release, and
+  that release then has to be correct" — did not occur. Adding the load fixed the
+  scenario and `region-success` still passed unchanged.
+
+Worth recording for the redesign: `VarDclNode.flowflags`, the *permanent* flow
+word (`ir/stmt/vardcl.h:20`), is zeroed in two places and never set or read
+anywhere. `VarFlowInfo.flags` in `ir/flow.c:159`, commented "the preserved flow
+flags", is likewise set to 0 and never used. **There is no durable flow record for
+later phases to consult.** That absence, not any individual bug, is the structural
+reason this class of defect keeps recurring.
+
+### The coercion swap costs nothing — measured, and it is the best buy
+
+Swapping `regionMatches(from->region, to->region)` to `(to->region, from->region)`
+at `ir/types/reference.c:181`: **the entire suite is unchanged except that
+`region-borrow-coerce` flips to XPASS.** No other scenario moved.
+
+Two things the survey missed:
+
+- **It is three lines, not one.** The same reversed call appears at
+  `ir/types/reference.c:226` (`refvirtMatchesRef`) and `ir/types/arrayref.c:82`
+  (`arrayRefMatchesRef`). Fixing only `refMatches` leaves virtual references and
+  ref-to-arrayref coercion still backwards. Swapping all three: **still zero
+  regressions.** Do all three or the hole stays open on two paths.
+- **Leave `ir/exp/cast.c:176` alone.** It is a fourth call in the same argument
+  order, but it asks a different question (`is` downcasting), where the regions
+  are normally identical so `EqMatch` fires first. Swapping it blind would be
+  guessing. Flag it for the redesign.
+
+Honest limit on "blast radius": the repository contains **no Cone source outside
+`test/cases/`** — 110 files, all of them the suite. `conesite/` ships HTML and a
+prebuilt `.wasm`, not compilable sources. So the suite *is* the measurable corpus,
+and "zero regressions" means zero across everything there is to measure. The
+direction the swap newly rejects is precisely the unsound one, so unmeasured
+breakage would have to be code that was already relying on the hole.
+
+### Confidence without a test: the problem dissolves on contact
+
+The work item says the dangerous half "cannot have a scenario until it is fixed".
+True, and the fix supplies one immediately. Probe — a borrowed reference passed to
+a `+rc-mut` parameter:
+
+```
+fn takesOwning(r +rc-mut i32) i32 { *r }
+fn f() i32 {
+  mut local = 7i32
+  takesOwning(&mut local)     // hands a stack address to an owning parameter
+}
+```
+
+Pristine compiler: **compiles clean, exit 0.** With the swap: `Error 1013:
+Expression's type does not match declared parameter`. So there is a real
+diagnostic to assert the moment the swap lands. The answer to "how would you gain
+confidence without a test" is: don't — fix it first, then pin it, in that order,
+in the same change. The scenario is about ten lines in a `reject` case.
+
+### A seventh defect, unrecorded, that limits the third stopgap
+
+`region-owning-field` pins a struct with an **`rc`** owning field. A struct with a
+**`+so`** owning field still corrupts the heap — with the GEP fix applied *and* on
+the pristine compiler, identically (`0xC0000374`, heap corruption):
+
+```
+struct HeldSo { r +so i32 }
+fn f() {
+  imm inner = +so 5
+  imm outer = +so HeldSo[r: inner]     // 'inner' is never deactivated
+  ...
+}
+```
+
+The cause is not in `region` at all: **a type literal's field initializers do not
+apply move semantics.** Passing a `@move` value as a call argument correctly
+raises `ErrorMove` (1048); placing the same value in a struct literal raises
+nothing, and the source variable stays live and stays on the dealias list. Hence
+the double free. It is independently a **use-after-move hole** — reading the
+moved-from variable afterwards compiles clean.
+
+This is not recorded in this item or in [[Add test suite]]'s survey, and the
+`move` group covers only moving *out of* an aggregate (`move-flow-aggregate`),
+never *into* one. It belongs to `move`, and it should be **handed to the redesign
+rather than patched**: making literals move changes which programs are legal,
+which is a language decision, not a stopgap.
+
+The consequence for scoping: the GEP fix is worth doing and covers the `rc` half,
+but it is a **partial** fix and should be labelled as one.
+
+### What to do
+
+Land as one small, obviously-temporary change, ~10 lines total:
+
+1. **Swap the region arguments at all three sites** (`reference.c:181` and `:226`,
+   `arrayref.c:82`). Silent unsoundness, measured cost zero, and it converts an
+   unassertable hole into an assertable one. Highest value on the page.
+2. **Skip moved variables in `flowScopeDealias`.** Silent double free, 2 lines.
+3. **Load the field in `genlDealiasFlds`.** Silent heap corruption, 2 lines,
+   `rc` half only.
+4. **Record first-assignment in flow and read it in `genlStore`.** Silent release
+   of garbage. The most invasive of the four — it adds a flag bit to the IR — and
+   the first to reconsider if the redesign starts soon.
+
+All four together: **98 passed, 4 XPASS, no regressions.**
+
+Where a hack would be worse than the defect:
+
+- **Do not make the `VarMoved` skip path-sensitive.** The flag is a running state,
+  so a variable moved on only one branch is skipped on every branch — that leaks.
+  A leak is strictly better than a double free, and making it precise means
+  per-program-point flow state, which is redesign work.
+- **Do not fix the struct-literal move gap** as a stopgap (above).
+- **Do not touch `cast.c:176`** without deciding what region downcasting means.
+- **Leave the two loud failures.** Confirmed still loud: nested allocation fails
+  module verification at compile time, and `?+rc-mut v` dies immediately with an
+  access violation (`0xC0000005`). Neither can be mistaken for working code.
+
+### Scenarios this implies — to write with the fix, not before
+
+- Drop `xfail` from `region-so-move`, `region-uninit-owning`, `region-owning-field`
+  and `region-borrow-coerce`; they become ordinary passing scenarios.
+- **New `reject` scenario** for the dangerous coercion half, now that it has a
+  diagnostic. It is `region`'s, alongside the other type-check scenarios.
+- **New `xfail`** for the `+so` owning field, recording the half the GEP fix does
+  not cover.
+- **New `xfail` in `move`** for the struct-literal move gap, with the
+  use-after-move probe — that is where the defect actually lives.
+
+### What this says about the five xfails
+
+The question of whether they survive the redesign largely evaporates: **four of
+the five would be retired by this change itself**, leaving only
+`region-nested-alloc`. And they behaved exactly as the item argues they would —
+each flipped to XPASS and failed the suite the moment its defect was fixed, which
+is how every measurement above was confirmed. They earned their keep this session.
+
+`region-success` is the asset the item says it is, and it proved it here: it
+passed unchanged under all four prototypes, which is what made "no regressions"
+a statement about behavior rather than about compilation.
+
 ## What the scenarios are worth, given a redesign is coming
 
 Five `xfail` scenarios sit in `test/cases/region/`. They cost nothing to keep and

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -10,8 +10,10 @@ Six defects in how owning references are generated and coerced, found by buildin
 the `region` group of the test suite. The evidence, with file and line, is under
 "Found while building the groups" in [[Add test suite]].
 
-**Five of the six are fixed.** Only fallible allocation remains of the original
-list. Tracing them uncovered four further defects, three of them fixed.
+**Five of the six are fixed**, and the sixth — fallible allocation — has been
+handed to [[Regions]], which owns the decision it needs. Tracing them uncovered
+five further defects, four of them fixed and the fifth rehomed. Nothing is left
+open here; see "What remains".
 
 ## Status
 
@@ -22,7 +24,7 @@ list. Tracing them uncovered four further defects, three of them fixed.
 | First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c` + `genlexpr.c` |
 | A struct's `rc` owning field corrupts the heap on release | Silent corruption | **Fixed** — `genlalloc.c:62` |
 | A nested allocation fails module verification | Loud, at compile time | **Fixed** — `genlallocref`'s phi |
-| Fallible allocation `?+rc-mut v` | Loud, immediately | **Open** — needs a lowering decision, see below |
+| Fallible allocation `?+rc-mut v` | Loud, immediately | **Moved** — the design is settled, see [[Regions]] |
 
 Found while fixing the above:
 
@@ -32,6 +34,7 @@ Found while fixing the above:
 | A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
 | An array literal's elements are never moved or copied | Silent, same shape | **Fixed** — `arrayLitFlow` |
 | An array literal cannot be generated unless its elements are constants | Loud, at compile time | **Fixed** — `genlExpr` builds with insertvalue |
+| A borrowed reference downcasts into an owning region | Silent unsoundness | **Fixed** — `cast.c:176` requires the regions to match |
 | Every array-reference allocation takes the fill path | **Silent, wrong data** | **Fixed** — `genlalloc.c:227` |
 
 The suite went from 111 scenarios / 98 passed / 14 xfail to **118 / 110 / 9**, and
@@ -162,52 +165,33 @@ with the semantic question it raises.
 
 ## What remains
 
-**The count a fill asks for cannot be asserted against generated code**, and the
-reason is not in this group: `genlExpr` builds an array literal with
-`LLVMConstArray`, so an element that is the result of an instruction — and an
-allocation always is — produces a constant array with instruction operands, and
-the module fails verification. It is true of an `i32` as much as of a reference,
-which is why nothing had noticed: the `array` group only ever writes constant
-elements. `array-nonconst-literal` records the cause and `region-fill-count` the
-consequence.
+**Nothing here.** Every defect this item was opened for is either fixed or has
+been handed to the item that owns the decision it needs:
 
-## Fallible allocation, and why it is not a repair
+- **Fallible allocation** goes to [[Regions]], with the design settled: allocation
+  always yields `Option[ref]`, `?+rc-mut v` hands that Option to the caller, and
+  plain `+rc-mut v` is sugar that unwraps and panics. The current lowering is
+  built the opposite way round, which is why it is a rebuild rather than a repair.
+- **What an array fill literal does about a runtime element count** goes to
+  [[Types. Array]], which already owns array literals. The general answer is to
+  rewrite a fill into a loop before the generation phase, so that dynamic aliasing
+  and generators are honored; it carries an open question about whether
+  `[3; f()]` should call `f` once or three times.
+- **Region downcasting** is settled rather than deferred: regions must match, and
+  there is no recast between them, because they are laid out differently. That is
+  now what `cast.c` enforces.
 
-The semantics are settled and code generation already implements them. A plain
-allocation traps when the allocator returns null; `?` sets `FlagQues`, which
-suppresses the trap so the null reaches the program. `Option[&T]` needs no tag or
-wrapper because `genltype.c:174` collapses a two-variant union whose other variant
-holds one pointer into a bare pointer — so "either a null or a real reference" is
-the literal runtime representation, and `genlexpr` specialises both testing it and
-constructing it. **None of this is redesign-blocked.** How a region signals failure
-is already fixed: `_alloc` returns `*u8` and the null check is in `genlallocref`.
+Two stopgaps here are deliberately temporary and belong to work already planned.
+The `VarMoved` skip is path-insensitive, so a value moved on one branch only is
+skipped on every branch and leaks — [[Copy & Alias vs. Move Semantics]] already
+plans the conditional-move flags that replace it. And `FlagFirstAssign` adds a
+flag bit to the IR that the redesign should reconsider first.
 
-What is broken is the front-end lowering, and it is structural rather than a slip:
-
-- **The allocate node's `vtype` ends up an expression.** Measured: for `+rc-mut 42`
-  it is `RefTag`; for `?+rc-mut 42` it stays `FnCallTag` — an un-instantiated
-  `Option[...]` in a type slot, which everything calling `itypeGetTypeDcl` then
-  walks as if it were a type.
-- **`itypeIsGenericType` is dead.** It is the only thing that can make
-  `isTypeNode()` true for a generic instantiation, and it tests for
-  `GenericNameTag`, which **nothing in the compiler ever assigns**. A written-out
-  `Option[T]` works only because the type parser instantiates it before anyone
-  asks the predicate; the `?` path has no such step.
-- **The lowering builds a cycle.** Name resolution points the allocate node's
-  `vtype` at the Option call whose `args[0]` *is that allocate node*, and type
-  check later patches it to a `RefNode` whose lex parent is the same allocate
-  node. Instantiating a generic across that recurses, which is why `?+rc-mut`
-  faults while `?+so` hangs.
-
-Substituting `itypeTypeCheck` for `inodeTypeCheckAny` gets `vtype` to a type node
-and still fails, so this is not a one-line repair. **The decision it needs** is
-where `?` lowers: instantiating `Option[T]` as a real type during name resolution,
-so the allocate node's `vtype` is a type from the outset, rather than an expression
-patched mid-type-check.
-
-Note the suite cannot hold this one either way. `?+so` hangs, and a scenario whose
-assertion is "this takes twenty seconds" asserts nothing — see "What cannot be a
-scenario at all" in [[Test Suite]].
+Two smaller things were found and left, neither belonging here: an array whose
+elements are owning references is never released at scope exit, because
+`flowScopeDealias` visits only variables whose own type is an owning reference;
+and `itypeIsGenericType` tests for a tag nothing in the compiler ever assigns,
+which makes it dead as written.
 
 ## What the scenarios are worth, given a redesign is coming
 

--- a/workitems/Ownership memory safety.md
+++ b/workitems/Ownership memory safety.md
@@ -10,22 +10,30 @@ Six defects in how owning references are generated and coerced, found by buildin
 the `region` group of the test suite. The evidence, with file and line, is under
 "Found while building the groups" in [[Add test suite]].
 
-**Four are now fixed by stopgaps.** Two remain, plus one more the stopgap work
-uncovered. This item stays open for those three.
+**Four of the six are fixed**, and the two that remain are the two loud ones,
+left deliberately. Tracing the fourth uncovered two further defects in how flow
+analysis treats literals; both are fixed, and one open sibling is recorded.
 
 ## Status
 
 | Defect | How it failed | State |
 | --- | --- | --- |
 | Region coercion reads backwards | Silent unsoundness | **Fixed** — `reference.c:181`, `:226`, `arrayref.c:82` |
-| A moved `+so` reference double-frees | Silent corruption | **Fixed** — `flow.c:205` |
-| First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c:170` + `genlexpr.c:819` |
+| A moved `+so` reference double-frees | Silent corruption | **Fixed** — `flow.c` |
+| First assignment to an uninitialized `rc` releases garbage | Silent corruption | **Fixed** — `assign.c` + `genlexpr.c` |
 | A struct's `rc` owning field corrupts the heap on release | Silent corruption | **Fixed** — `genlalloc.c:62` |
-| A struct's `+so` owning field double-frees | Silent corruption | **Open** — `region-owning-field-so` |
 | A nested allocation | Loud, at compile time | **Open, deliberately** — `region-nested-alloc` |
 | Fallible allocation `?+rc-mut v` | Loud, immediately | **Open, deliberately** — [[Diagnose instead of crash]] |
 
-The suite went from 111 scenarios / 98 passed / 14 xfail to **114 / 103 / 12**.
+Found while fixing the above:
+
+| Defect | How it failed | State |
+| --- | --- | --- |
+| A type literal's field values are never moved or copied | Silent corruption, and a use-after-move | **Fixed** — `typeLitFlow` |
+| A temporary's reference is counted as a second holder | Silent leak | **Fixed** — `flowHandleMoveOrCopy` |
+| An array literal's elements are never moved or copied | Silent, same shape | **Open** — `move-flow-arraylit` |
+
+The suite went from 111 scenarios / 98 passed / 14 xfail to **115 / 105 / 11**.
 
 ## The question this work item asks
 
@@ -91,19 +99,47 @@ outside `test/cases/`, so the suite is the whole measurable corpus.
 - `FlagFirstAssign` adds a flag bit to the IR. It is the most entrenching of the
   four and the first to reconsider once the redesign starts.
 
+## What a reference count means, and the two defects that followed
+
+Tracing the `+so` owning field led out of this group entirely, into what the count
+counts. The rule is that **the count is how many holders exist**:
+
+- `+rc[2]` creates the object *and* the first reference to it. Born at 1.
+- `imm a = +rc[2]` adds no holder. The temporary hands its reference to `a`, so
+  the count stays 1.
+- `imm b = a` does add one — `a` keeps its reference and `b` gets another — so 2.
+- `+so` is the same shape with the second holder forbidden, so binding from an
+  existing holder deactivates the source instead of counting it.
+
+Two defects followed from the compiler not expressing that.
+
+**`iexpIsMove` tests the type alone**, and `+rc-mut 7` and `a` have the same type.
+A type-only test cannot tell a temporary handing over its reference from an
+lvalue that keeps one, so `flowHandleMoveOrCopy` aliased both and every allocation
+bound to a variable was born at 1, aliased to 2, released once, and **leaked**.
+The suite could not see it: a `run` scenario observes stdout, not the heap. The
+fix is one condition — alias only an lvalue read.
+
+**A type literal was a leaf to flow analysis.** `TypeLitTag` sat in the same
+`switch` bucket as `ULitTag` and `StringLitTag`, so its field values were never
+visited: no move, no alias, no lifetime check. That is why a `+so` owning field
+double-freed — the source variable was never deactivated — and it was
+independently a **use-after-move hole**. A type literal is a `FnCallNode`, so it
+now does what a call does with its arguments, unwrapping the `NamedValNode` that
+wraps a value given by field name.
+
+Neither turned out to need a language decision. Both are the type's existing rule
+applied where it was not being applied.
+
 ## What remains
 
-**A `+so` owning field still double-frees**, and the cause is not in this group: a
-type literal's field initializers do not apply move semantics, so naming a
-variable in a literal never deactivates it. Passing the same value as a call
-argument does deactivate it. That gap is independently a **use-after-move hole** —
-reading the moved-from variable afterwards compiles clean — and it is recorded as
-`move-flow-literal` in the `move` group, with `region-owning-field-so` recording
-the consequence here.
-
-**Closing it is a language decision, not a codegen fix**: it settles whether a
-literal moves or copies its initializers. It is handed to the redesign rather than
-patched.
+**An array literal has the same gap** — `ArrayLitTag` is still a leaf, so
+`[hd, Handle[8]]` does not deactivate `hd`. It is **not** the same fix, which is
+why it is recorded rather than made: an array literal has a second form, the fill
+`[n; value]`, which repeats one expression across n elements. A move value cannot
+be moved into n slots, and a counted reference would need n added rather than one.
+**What a fill does to a move or counted value is undecided**, and that is the
+blocker. `move-flow-arraylit` pins the list form, which is not in doubt.
 
 **The two loud failures stay open deliberately.** Neither can be mistaken for
 working code — nested allocation fails module verification at compile time, and
@@ -118,7 +154,9 @@ suite the moment the behavior changes — including as a side effect of the rede
 which is exactly when you want to be told.
 
 That is not a prediction any more. Four of the five did precisely this during the
-stopgap work, and each flip is how the corresponding fix was confirmed.
+stopgap work, and each flip is how the corresponding fix was confirmed. So did
+both scenarios written afterwards to record newly found defects — one of which
+was fixed within the hour, by the scenario telling us it had been.
 
 If the redesign changes the spelling of regions, the remaining scenarios will need
 rewriting rather than deleting. `region-success` is the one to protect: 37

--- a/workitems/Regions.md
+++ b/workitems/Regions.md
@@ -19,6 +19,51 @@ See [[Init and Final]]
 Allocation
 - Region alloc or init failure can either panic or produce Option value 
 
+### Fallible allocation: `?+rc-mut value`
+
+**Allocation always yields `Option[ref]`.** The primitive can fail, so that is its
+honest return type. `?+rc-mut value` is the form that hands the caller that Option
+to test. Plain `+rc-mut value` is sugar over it — the equivalent of an
+`Option.memallocpanic` — which unwraps and panics when the allocation returned
+None.
+
+So the syntax is deliberately the inverse of the semantics: the shorter spelling
+is the *more derived* operation. Panicking is overwhelmingly the common case and
+should not be the verbose one, while a program willing to handle allocation
+failure opts in with `?`.
+
+Code generation already works this way and needs no change. `genlallocref` emits
+the null check as a branch to a panic block and calls `genlPanic` there only when
+`FlagQues` is absent. `Option[&T]` needs no tag or wrapper, because `genltype.c`
+collapses a two-variant union whose other variant holds a single pointer into a
+bare pointer — so "a null or a real reference" is the literal representation, and
+`genlexpr` specialises both testing it and constructing it.
+
+**What is broken is the lowering, and it is built the wrong way round**: plain
+allocation is the primitive and `?` is a modifier bolted onto it, the opposite of
+the model above. Today `?+rc-mut v` dies on an access violation and `?+so v`
+hangs. Specifically:
+
+- The allocate node's `vtype` stays an un-instantiated `Option[...]` **expression**
+  (`FnCallTag`) sitting in a type slot, where the non-`?` form has a real `RefTag`.
+- `itypeIsGenericType` — the only thing that can make `isTypeNode()` true for a
+  generic instantiation — tests for `GenericNameTag`, a tag **nothing in the
+  compiler ever assigns**. A written-out `Option[T]` works only because the type
+  parser instantiates it before anything asks.
+- Name resolution builds a cycle: the allocate node's `vtype` is the Option call
+  whose `args[0]` *is* that allocate node, patched mid-type-check to a `RefNode`
+  whose lex parent is the same allocate node. Instantiating a generic across that
+  recurses, which is why one form faults and the other hangs.
+
+Substituting `itypeTypeCheck` for `inodeTypeCheckAny` gets the `vtype` to a type
+node and still fails, so this is not a repair to the existing lowering. Building it
+the way round described above is the fix.
+
+The test suite cannot hold this defect in any form: `?+so` hangs, and a scenario
+whose assertion is "this takes twenty seconds" asserts nothing. The crash half is
+cross-listed to [[Diagnose instead of crash]]; it was found by [[Add test suite]]
+and triaged in [[Ownership memory safety]], which carries the rest of that survey.
+
 Alloc and init for array references
 - Function-based initialization
 

--- a/workitems/Types. Array.md
+++ b/workitems/Types. Array.md
@@ -12,3 +12,39 @@ Array
 
 Slice creation and member support
 
+## Rewriting a fill literal into a loop
+
+A fill literal `[n; value]` evaluates one expression and stores the result into
+every element. Flow analysis now applies the ownership rules to it as far as a
+constant can carry them: a move value may not be filled at all, since it has one
+owner and cannot have n, and a counted reference raises the count by n — or by
+n-1 when the value is a temporary handing over the reference it was born with.
+That amount lives in the injected alias node as a compile-time constant, so a
+count known only at run time is refused rather than counted wrongly.
+
+**The general fix is to rewrite a fill literal into a loop that constructs the
+array's elements one at a time, and to do it well before the generation phase.**
+Two things need that, and neither can be reached from where the work sits now.
+A run-time element count needs a run-time count adjustment, which a constant
+`aliasamt` cannot express — this is the "Array non-literal literals (w/
+variables)" bullet above, seen from the ownership side. And a generator, an
+element expression yielding a different value per element, has no meaning at all
+while the expression is evaluated once outside the array. Doing the rewrite early
+is what makes both ordinary: the loop body goes through normal flow analysis and
+aliasing like any other code, instead of code generation special-casing a fill
+and every ownership rule having to be restated for it.
+
+**One semantic question comes with the rewrite.** Today `[3; f()]` calls `f` once
+and stores the result three times. A loop would make it three calls unless the
+rewrite deliberately hoists the expression out, and which of those is meant is a
+language decision rather than an implementation detail. It is the same question
+as "Handle single-element initialization, value and closure" above, asked about a
+call instead of a closure.
+
+Note that none of this is observable yet for a value that is not a compile-time
+constant, in either literal form: `genlExpr` builds an array literal with
+`LLVMConstArray`, so an element that is the result of an instruction produces a
+constant array with instruction operands and the module fails verification.
+`array-nonconst-literal` records it, and `region-fill-count` records that a
+counted fill cannot be asserted against generated code until it is fixed.
+

--- a/workitems/__Top Priority.md
+++ b/workitems/__Top Priority.md
@@ -11,7 +11,10 @@
 	- [[Types. Pointers and Borrowed References]]
 
 Add test suite is done; see `workitems/done/`. It left four unplaced follow-ups,
-listed under Compiler Components in [[_index]] and not slotted here yet:
-[[Ownership memory safety]], [[Diagnose instead of crash]],
+listed under Compiler Components in [[_index]] and not slotted here yet.
+[[Ownership memory safety]] is now done as well, and what it did not settle went
+to the items that own those decisions: fallible allocation to [[Regions]], array
+fill literals to [[Types. Array]], and two loose defects to
+[[Compiler defect backlog]]. Still unplaced: [[Diagnose instead of crash]],
 [[Unenforced language rules]], [[Compiler defect backlog]].
 

--- a/workitems/_index.md
+++ b/workitems/_index.md
@@ -57,7 +57,7 @@
 	- [[Analysis re-factor]]
 	- Generation: [[LLVM Generation]] and [[C-ABI Generation]]
 	- Defects the test suite found, by the decision each needs:
-		- [[Ownership memory safety]] — miscompiles, and one soundness hole
+		- [[Ownership memory safety]] — miscompiles in provisional region code, awaiting its redesign
 		- [[Diagnose instead of crash]] — error paths that dereference their own NULL
 		- [[Unenforced language rules]] — documented rules nothing checks
 		- [[Compiler defect backlog]] — the residue, each with a clear answer

--- a/workitems/_index.md
+++ b/workitems/_index.md
@@ -57,7 +57,7 @@
 	- [[Analysis re-factor]]
 	- Generation: [[LLVM Generation]] and [[C-ABI Generation]]
 	- Defects the test suite found, by the decision each needs:
-		- [[Ownership memory safety]] — four stopgaps landed; a `+so` owning field and two loud failures await the redesign
+		- [[Ownership memory safety]] — the silent defects are fixed; two loud failures and array-literal move semantics remain
 		- [[Diagnose instead of crash]] — error paths that dereference their own NULL
 		- [[Unenforced language rules]] — documented rules nothing checks
 		- [[Compiler defect backlog]] — the residue, each with a clear answer

--- a/workitems/_index.md
+++ b/workitems/_index.md
@@ -57,7 +57,7 @@
 	- [[Analysis re-factor]]
 	- Generation: [[LLVM Generation]] and [[C-ABI Generation]]
 	- Defects the test suite found, by the decision each needs:
-		- [[Ownership memory safety]] — the silent defects are fixed; two loud failures and array-literal move semantics remain
+		- [[Ownership memory safety]] — the silent defects are fixed; three loud compile-time failures remain
 		- [[Diagnose instead of crash]] — error paths that dereference their own NULL
 		- [[Unenforced language rules]] — documented rules nothing checks
 		- [[Compiler defect backlog]] — the residue, each with a clear answer

--- a/workitems/_index.md
+++ b/workitems/_index.md
@@ -57,7 +57,7 @@
 	- [[Analysis re-factor]]
 	- Generation: [[LLVM Generation]] and [[C-ABI Generation]]
 	- Defects the test suite found, by the decision each needs:
-		- [[Ownership memory safety]] — miscompiles in provisional region code, awaiting its redesign
+		- [[Ownership memory safety]] — four stopgaps landed; a `+so` owning field and two loud failures await the redesign
 		- [[Diagnose instead of crash]] — error paths that dereference their own NULL
 		- [[Unenforced language rules]] — documented rules nothing checks
 		- [[Compiler defect backlog]] — the residue, each with a clear answer

--- a/workitems/_index.md
+++ b/workitems/_index.md
@@ -57,7 +57,7 @@
 	- [[Analysis re-factor]]
 	- Generation: [[LLVM Generation]] and [[C-ABI Generation]]
 	- Defects the test suite found, by the decision each needs:
-		- [[Ownership memory safety]] — the silent defects are fixed; three loud compile-time failures remain
+		- [[Ownership memory safety]] — done; see `workitems/done/`
 		- [[Diagnose instead of crash]] — error paths that dereference their own NULL
 		- [[Unenforced language rules]] — documented rules nothing checks
 		- [[Compiler defect backlog]] — the residue, each with a clear answer

--- a/workitems/done/Ownership memory safety.md
+++ b/workitems/done/Ownership memory safety.md
@@ -1,5 +1,17 @@
 # Ownership memory safety
 
+> **Done.** Nine defects fixed, two decisions settled, and what needed a design
+> answer was handed to the item that owns it: fallible allocation to [[Regions]],
+> array fill literals to [[Types. Array]], two loose defects to
+> [[Compiler defect backlog]]. The suite went from 111 scenarios / 98 passed / 14
+> expected failures to **118 / 110 / 9**, and the `region` group carries no
+> expected failures at all.
+>
+> Read the "Status" table for what moved, and "What measuring the stopgaps
+> showed" for the parts worth carrying into the region redesign — chiefly that
+> there is no durable flow record for later phases to consult, which is the
+> structural reason this class of defect kept recurring.
+
 > **These are defects in provisional code.** Regions are only partly built and
 > were never robustly designed; a redesign carrying substantially new ideas is
 > intended, and getting that design right is the priority. Nothing here should be


### PR DESCRIPTION
Started as a design pass — recommend how to fix six ownership defects before the region redesign lands — and grew into the fixes once measuring showed most of them were cheap and the two that weren't turned out to be settled questions rather than open ones.

## What changed

Nine defects fixed. Five of the original six, plus four more found by tracing them.

| Defect | Failed as | Fix |
| --- | --- | --- |
| Region coercion compared its arguments backwards | Silent unsoundness | `reference.c` ×2, `arrayref.c` |
| A moved `+so` reference double-freed | Silent corruption | `flowScopeDealias` skips moved variables |
| First assignment to an uninitialized `rc` released garbage | Silent corruption | flow marks the assignment site |
| A struct's `rc` owning field corrupted the heap | Silent corruption | load the field, don't pass its address |
| A type literal's field values were never moved or copied | Silent corruption + use-after-move | `typeLitFlow` |
| A temporary's reference was counted as a second holder | Silent leak | alias only an lvalue read |
| An array literal's elements were never moved or copied | Silent, same shape | `arrayLitFlow` |
| Every array-reference allocation took the fill path | **Silent, wrong data** | test the count, not the pointer |
| A borrowed reference downcast into an owning region | Silent unsoundness | regions must match |
| A nested allocation failed module verification | Loud | read the phi's blocks back from the builder |
| An array literal needed constant elements | Loud | build with `insertvalue` when computed |

## Two rules settled

**A reference count is how many holders exist.** `+rc[2]` creates the object *and* the first reference, so binding that temporary adds no holder — it hands the reference over. Only an lvalue read adds one. `iexpIsMove` tested the type alone and could not tell those apart, so every allocation bound to a variable leaked. An array fill generalises it: n holders from an lvalue, n−1 from a temporary, with the ordinary case being n = 1.

**Regions must match when downcasting.** They are laid out differently, so there is no recast between them, not even into a borrow.

## Suite

111 scenarios / 98 passed / 14 expected failures → **118 / 110 / 9**. The `region` group now carries no expected failures at all. `--bless` records no drift.

Seven scenarios that recorded defects were rewritten to assert the behaviour instead. New coverage pins the coercion direction that must stay refused, the fill amount (read out of the generated IR, which is the only place the number is visible), an allocated slice — the `collection` group had only ever covered borrowed ones — and two defects left open.

## Not fixed, and why

- **Fallible allocation** → [[Regions]]. Allocation always yields `Option[ref]`; `?+rc-mut v` hands that Option to the caller and plain `+rc-mut v` is sugar that unwraps and panics. The current lowering is built the opposite way round, which makes it a rebuild rather than a repair. Codegen already implements the model.
- **Array fill with a runtime element count** → [[Types. Array]]. Wants the loop rewrite, which needs the generator and dynamic-aliasing design.
- Two loose defects → [[Compiler defect backlog]].

## Known costs

The `VarMoved` skip is path-insensitive: a value moved on one branch only is skipped on all of them and leaks. That is strictly better than a double free, and [[Copy & Alias vs. Move Semantics]] already plans the conditional-move flags that replace it. `FlagFirstAssign` adds an IR flag bit that the redesign should reconsider first.

Two `llvmir` needles pin register numbers, read from a real dump rather than invented. They will give a spurious failure if surrounding codegen shifts; the reasoning is recorded next to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
