### PR TITLE
Give each generated symbol its own COMDAT, so the linker can drop it

### DIFF
--- a/design/nodes/module.md
+++ b/design/nodes/module.md
@@ -264,6 +264,15 @@ module, and two sibling module folders can declare the same module name.
   a file path — and its declarations arrive **externally supplied**: declared
   for the linker, never defined by this compile. That subsumes `extern` for Cone
   packages; the importer writes no `extern` keyword.
+- **What monomorphizes or expands at the use site is the exception, and the
+  importer defines it.** A generic instance, an expanded macro, an `inline` body
+  and a cloned trait default have no definition in the imported package to link
+  against, because the package cannot know which ones exist — the same reason
+  the interface artifact below cannot hold signatures alone. So an importing
+  compile does emit definitions for those, and `LLVMLinkOnceAnyLinkage` is what
+  lets several importers each emit the same one. This is the whole of the
+  exception: it does not extend to anything the imported package could have
+  emitted itself.
 - **A module imports a given package at most once.** A second import of the same
   package with an identical fold spec is silently ignored; a differing one is an
   error. Identity is the resolved package plus the normalized fold spec — the

--- a/design/phases/generation.md
+++ b/design/phases/generation.md
@@ -23,6 +23,9 @@ unreachable paths are reading only, and say so. See [Measuring](../diagnostics/m
 4. **Generation decides nothing about memory.** Every release, every count
    adjustment, every drop call was injected by flow analysis. Generation replays
    the lists.
+5. **Every definition is separately discardable.** Each one leads a COMDAT of
+   its own, so the linker decides at symbol granularity what ships rather than
+   at object-file granularity.
 
 ## 2. Ordering, and why setup runs before parsing
 
@@ -44,29 +47,45 @@ Both recurse into a type's method list and into a generic's
 `genericinfo->memonodes`. Generic instances get `LLVMLinkOnceAnyLinkage`. An
 uninstantiated generic generates nothing.
 
-**Each definition leads a COMDAT of its own, named for its symbol** — every
-function and every global variable. Without one a section is all-or-nothing, so
-every function an object file defines ships whether or not the program can reach
-it; with one the linker discards the unreachable ones and, transitively,
-whatever only they called. The attachment is at the definition sites, `genlFn`
-and `genlGloVar`, and not in the symbol pass, because **only a definition may
-lead a COMDAT**: an imported module's functions have bodies in the IR but are
-declarations in this object, and `LLVMVerifyModule` rejects a declaration in a
-COMDAT. Hidden visibility does not prevent it — a private function strips like
-any other.
+### Symbols, linkage and COMDATs
 
-**The selection kind follows the linkage.** `any` merges silently, keeping one
-copy of a symbol several object files each define. That is what a generic
-instantiation needs and what nothing else should ask for, so everything not
-`linkonce` or `weak` gets `nodeduplicate` instead, leaving a genuine duplicate
-definition the link error it should be.
+A section is all-or-nothing, so without further help every function an object
+file defines ships whether or not the program can reach it. **Each definition
+leads a COMDAT of its own, named for its symbol**, which lets the linker discard
+the unreachable ones and, transitively, whatever only they referenced.
 
-**Not every object format has them, so `genSetup` asks the triple** and stores
-the answer in `gen->comdats`. Mach-O has no COMDAT concept at all and needs
-none — its assembler emits `.subsections_via_symbols`, which already lets the
-linker strip a symbol at a time — while WebAssembly lowers only `any`, so on
-wasm every symbol is mergeable whether it wants to be or not. Both restrictions
-are hard errors inside LLVM's backend, not something it works around.
+**Two questions have to be answered for every generated global, and they are not
+independent.** The caller chooses the linkage; `genlComdat` derives the rest, so
+a new kind of symbol has only to get its linkage right and cannot end up with a
+selection kind that contradicts it:
+
+| What the symbol is | Linkage the caller sets | What `genlComdat` then does |
+| --- | --- | --- |
+| a definition only this object can supply | external | `nodeduplicate` — a duplicate definition is a real error and stays one |
+| a definition several objects may each supply — a generic instance, a vtable | `linkonce` | `any` — the linker keeps one copy and says nothing |
+| a definition nothing outside can name — an anonymous `fn`, a string literal | `internal` | `nodeduplicate`; nothing can collide with it in any case |
+| a declaration — an imported module's function, an `extern` | external | nothing: **only a definition may lead a COMDAT**, and `LLVMVerifyModule` rejects one that does not |
+
+That last row is why the attachment is at the definition sites and not in the
+symbol pass. An imported module's functions have bodies in the IR and are
+declarations in this object; `genlGloFnName` cannot tell, because the
+`FlagGenMod` that separates them is tested a level up.
+
+**The rule reaches only what passes through `genlComdat`.** A global built with
+`LLVMAddGlobal` and never handed to it sits in a shared section, is not
+individually discardable, and keeps alive everything it names. A vtable did
+exactly that: a struct coerced to `&<Trait` kept every one of its trait methods
+in the image whether or not anything ever dispatched. The call sites are
+`genlFn`, `genlGloVar`, `genlVtableImpl`, `genlVtable`, and the `StringLitTag`
+case in `genlAddr`. **A new kind of generated global needs a sixth.**
+
+**Not every object format has COMDATs, so `genSetup` asks the triple** and stores
+the answer in `gen->comdats`. Mach-O has no COMDAT concept and needs none — its
+assembler emits `.subsections_via_symbols`, which already lets the linker strip a
+symbol at a time — while WebAssembly lowers only `any`, so on wasm every symbol
+is mergeable whether it wants to be or not. Both are hard errors inside LLVM's
+backend rather than something it works around, and the C API exposes no
+object-format query.
 
 **An anonymous `fn` literal is given a name and internal linkage** in `genlFn`,
 because it is lifted to module scope with neither. It needs a name for a COMDAT

--- a/design/phases/generation.md
+++ b/design/phases/generation.md
@@ -44,6 +44,39 @@ Both recurse into a type's method list and into a generic's
 `genericinfo->memonodes`. Generic instances get `LLVMLinkOnceAnyLinkage`. An
 uninstantiated generic generates nothing.
 
+**Each definition leads a COMDAT of its own, named for its symbol** — every
+function and every global variable. Without one a section is all-or-nothing, so
+every function an object file defines ships whether or not the program can reach
+it; with one the linker discards the unreachable ones and, transitively,
+whatever only they called. The attachment is at the definition sites, `genlFn`
+and `genlGloVar`, and not in the symbol pass, because **only a definition may
+lead a COMDAT**: an imported module's functions have bodies in the IR but are
+declarations in this object, and `LLVMVerifyModule` rejects a declaration in a
+COMDAT. Hidden visibility does not prevent it — a private function strips like
+any other.
+
+**The selection kind follows the linkage.** `any` merges silently, keeping one
+copy of a symbol several object files each define. That is what a generic
+instantiation needs and what nothing else should ask for, so everything not
+`linkonce` or `weak` gets `nodeduplicate` instead, leaving a genuine duplicate
+definition the link error it should be.
+
+**Not every object format has them, so `genSetup` asks the triple** and stores
+the answer in `gen->comdats`. Mach-O has no COMDAT concept at all and needs
+none — its assembler emits `.subsections_via_symbols`, which already lets the
+linker strip a symbol at a time — while WebAssembly lowers only `any`, so on
+wasm every symbol is mergeable whether it wants to be or not. Both restrictions
+are hard errors inside LLVM's backend, not something it works around.
+
+**An anonymous `fn` literal is given a name and internal linkage** in `genlFn`,
+because it is lifted to module scope with neither. It needs a name for a COMDAT
+to be named after, and internal linkage because the name LLVM's mangler invents
+for an unnamed symbol — `__unnamed_1` — is the one every other object file
+invents too. Internal linkage also lets the inliner delete the ones nothing
+calls, so an unused literal never reaches the object file. The suffix LLVM
+appends to keep `anon` unique is the module symbol table's counter, so it shifts
+when unrelated globals are added.
+
 `genlFn` per function: entry block, a dummy `allocaPoint` alloca, an alloca and
 store for **every** parameter, then `genlBlock` on the body, then erase the
 alloca point. Every parameter and local is memory-backed on purpose — the
@@ -284,6 +317,8 @@ variables.
 | | `genlProgram` | the two-pass symbols-then-implementations walk |
 | | `genlGlobalSyms`, `genlGlobalImpl` | declare a node's symbol; emit its body |
 | | `genlFn`, `genlParmVar`, `genlAlloca` | function body, parameter allocas, entry-block alloca placement |
+| | `genlComdat`, `genlNameAnonFn` | the per-definition COMDAT that lets the linker drop a symbol; the private name an anonymous `fn` needs to have one |
+| | `genlComdatSupport` | what the target's object format does with COMDATs |
 | | `genlOut` | set triple and layout, emit object and asm |
 | `genllvm/genltype.c` | `genlType`, `_genlType` | the memoizing entry and the per-tag lowering switch |
 | | `genlSetupTaggedTrait`, `genlSameSizeTrait` | the three union shapes |

--- a/src/c-compiler/genllvm/genlexpr.c
+++ b/src/c-compiler/genllvm/genlexpr.c
@@ -920,6 +920,7 @@ LLVMValueRef genlAddr(GenState *gen, INode *lval) {
         LLVMValueRef sglobal = LLVMAddGlobal(gen->module, genlType(gen, strnode->vtype), "string");
         LLVMSetLinkage(sglobal, LLVMInternalLinkage);
         LLVMSetGlobalConstant(sglobal, 1);
+        genlComdat(gen, sglobal);
         LLVMSetInitializer(sglobal, LLVMConstStringInContext(gen->context, strnode->strlit, strnode->strlen, 1));
         return sglobal;
     }

--- a/src/c-compiler/genllvm/genllvm.c
+++ b/src/c-compiler/genllvm/genllvm.c
@@ -18,6 +18,7 @@
 #include <llvm-c/Target.h>
 #include <llvm-c/Analysis.h>
 #include <llvm-c/BitWriter.h>
+#include <llvm-c/Comdat.h>
 #include <llvm-c/Transforms/Scalar.h>
 #include <llvm-c/Transforms/IPO.h>
 #if LLVM_VERSION_MAJOR >= 7
@@ -44,6 +45,51 @@ void genlParmVar(GenState *gen, VarDclNode *var) {
     LLVMBuildStore(gen->builder, LLVMGetParam(gen->fn, var->index), var->llvmvar);
 }
 
+// Put a generated global in a COMDAT of its own, named for the symbol itself.
+// A COFF section is otherwise all-or-nothing: without this, every function an
+// object file defines ships in the executable, whether or not the program can
+// reach it. With it, the linker discards the unreachable ones (/OPT:REF), and
+// transitively their callees too. Only a definition may lead a COMDAT, so this
+// belongs with generating the body, not with generating the name: an imported
+// module's functions have bodies in the IR but are only declarations here.
+//
+// The selection kind says what the linker does when two object files both
+// supply the symbol. Merging is what a generic instantiation needs and what
+// nothing else wants: 'any' silently keeps one copy, which for every other
+// symbol would turn a duplicate definition from a link error into a coin toss.
+// So it follows the linkage the caller already chose.
+static void genlComdat(GenState *gen, LLVMValueRef global) {
+    if (gen->comdats == ComdatNone)
+        return;
+
+    size_t namelen;
+    const char *name = LLVMGetValueName2(global, &namelen);
+    assert(namelen > 0 && "a COMDAT is named for its symbol, so the symbol needs a name");
+    LLVMLinkage linkage = LLVMGetLinkage(global);
+    int mergeable = linkage == LLVMLinkOnceAnyLinkage || linkage == LLVMLinkOnceODRLinkage
+                 || linkage == LLVMWeakAnyLinkage || linkage == LLVMWeakODRLinkage;
+
+    LLVMComdatRef comdat = LLVMGetOrInsertComdat(gen->module, name);
+    LLVMSetComdatSelectionKind(comdat,
+        (mergeable || gen->comdats == ComdatMergeOnly)?
+            LLVMAnyComdatSelectionKind : LLVMNoDeduplicateComdatSelectionKind);
+    LLVMSetComdat(global, comdat);
+}
+
+// An anonymous 'fn' literal is lifted to module scope with no name at all.
+// Give it one that is private to this object file. It needs a name to lead a
+// COMDAT, and it needs private linkage because nothing outside this object can
+// refer to it: left public, the name LLVM's mangler invents is one that every
+// other object file would invent too, and the two would collide.
+static void genlNameAnonFn(GenState *gen, LLVMValueRef fn) {
+    size_t namelen;
+    LLVMGetValueName2(fn, &namelen);
+    if (namelen > 0)
+        return;
+    LLVMSetValueName2(fn, "anon", 4);   // LLVM appends a suffix to keep it unique
+    LLVMSetLinkage(fn, LLVMInternalLinkage);
+}
+
 // Generate a function
 void genlFn(GenState *gen, FnDclNode *fnnode) {
     // Only a concrete declaration has an implementation. An overload name is a
@@ -51,6 +97,9 @@ void genlFn(GenState *gen, FnDclNode *fnnode) {
     assert(fnnode->tag == FnDclTag && "Only a concrete function/method is generated");
     if ((fnnode->flags & FlagInline) || fnnode->value->tag == IntrinsicTag)
         return;
+
+    genlNameAnonFn(gen, fnnode->llvmvar);
+    genlComdat(gen, fnnode->llvmvar);
 
     LLVMValueRef svfn = gen->fn;
     LLVMBuilderRef svbuilder = gen->builder;
@@ -106,6 +155,11 @@ LLVMValueRef genlAlloca(GenState *gen, LLVMTypeRef type, const char *name) {
 
 // Generate global variable
 void genlGloVar(GenState *gen, VarDclNode *varnode) {
+    // An extern global is defined in some other object file; this one only
+    // names it, and a declaration may not lead a COMDAT
+    if (!(varnode->flags & FlagExtern))
+        genlComdat(gen, varnode->llvmvar);
+
     if (!varnode->value) {
         // If no value on non-extern, initialize with the zero initializer
         if (!(varnode->flags & FlagExtern))
@@ -529,6 +583,20 @@ void genpgm(GenState *gen, ProgramNode *pgm) {
 }
 
 // Setup LLVM generation, ensuring we know intended target
+// Which COMDAT selection kinds this target's object format will lower. Both
+// restrictions are hard errors inside LLVM's backend rather than something it
+// works around, and the C API exposes no object-format query, so ask the triple.
+static int genlComdatSupport(char *triple) {
+    if (strstr(triple, "wasm") || strstr(triple, "emscripten"))
+        return ComdatMergeOnly;
+    // Mach-O needs none: its assembler emits .subsections_via_symbols, which
+    // already lets the linker strip a symbol at a time
+    if (strstr(triple, "darwin") || strstr(triple, "apple")
+        || strstr(triple, "macos") || strstr(triple, "ios"))
+        return ComdatNone;
+    return ComdatFull;
+}
+
 void genSetup(GenState *gen, ConeOptions *opt) {
     gen->opt = opt;
 
@@ -549,6 +617,7 @@ void genSetup(GenState *gen, ConeOptions *opt) {
     gen->blockstack = memAllocBlk(sizeof(GenBlockState)*GenBlockStackMax);
     gen->blockstackcnt = 0;
 
+    gen->comdats = genlComdatSupport(opt->triple);   // genlCreateMachine filled in the default
     gen->emptyStructType = genlEmptyStruct(gen);
 }
 

--- a/src/c-compiler/genllvm/genllvm.c
+++ b/src/c-compiler/genllvm/genllvm.c
@@ -58,7 +58,7 @@ void genlParmVar(GenState *gen, VarDclNode *var) {
 // nothing else wants: 'any' silently keeps one copy, which for every other
 // symbol would turn a duplicate definition from a link error into a coin toss.
 // So it follows the linkage the caller already chose.
-static void genlComdat(GenState *gen, LLVMValueRef global) {
+void genlComdat(GenState *gen, LLVMValueRef global) {
     if (gen->comdats == ComdatNone)
         return;
 

--- a/src/c-compiler/genllvm/genllvm.h
+++ b/src/c-compiler/genllvm/genllvm.h
@@ -66,6 +66,7 @@ void genSetup(GenState *gen, ConeOptions *opt);
 void genClose(GenState *gen);
 void genpgm(GenState *gen, ProgramNode *pgm);
 void genlFn(GenState *gen, FnDclNode *fnnode);
+void genlComdat(GenState *gen, LLVMValueRef global);
 void genlGloVarName(GenState *gen, VarDclNode *glovar);
 void genlGloFnName(GenState *gen, FnDclNode *glofn);
 

--- a/src/c-compiler/genllvm/genllvm.h
+++ b/src/c-compiler/genllvm/genllvm.h
@@ -41,10 +41,19 @@ typedef struct GenState {
     LLVMTypeRef emptyStructType;
 
     ConeOptions *opt;
+    int comdats;            // enum ComdatSupport, from the target's object format
     INode *fnblock;
     GenBlockState *blockstack;
     uint32_t blockstackcnt;
 } GenState;
+
+// What the target's object file format does with COMDATs, which is how a
+// symbol becomes individually discardable
+enum ComdatSupport {
+    ComdatNone,        // Mach-O has no COMDAT concept at all
+    ComdatMergeOnly,   // WebAssembly lowers only the 'any' selection kind
+    ComdatFull         // COFF and ELF lower both kinds
+};
 
 // Different kinds of dispatch
 enum FnCallDispatch {

--- a/src/c-compiler/genllvm/genltype.c
+++ b/src/c-compiler/genllvm/genltype.c
@@ -63,6 +63,7 @@ void genlVtableImpl(GenState *gen, VtableImpl *impl, LLVMTypeRef vtableRef) {
     impl->llvmvtablep = LLVMAddGlobal(gen->module, vtableRef, impl->name);
     LLVMSetGlobalConstant(impl->llvmvtablep, 1);
     LLVMSetLinkage(impl->llvmvtablep, LLVMLinkOnceAnyLinkage);
+    genlComdat(gen, impl->llvmvtablep);
     LLVMSetInitializer(impl->llvmvtablep, implRef);
 }
 
@@ -117,6 +118,7 @@ void genlVtable(GenState *gen, Vtable *vtable) {
     vtable->llvmvtables = LLVMAddGlobal(gen->module, LLVMTypeOf(vtablelist), "vtable-list");
     LLVMSetGlobalConstant(vtable->llvmvtables, 1);
     LLVMSetLinkage(vtable->llvmvtables, LLVMLinkOnceAnyLinkage);
+    genlComdat(gen, vtable->llvmvtables);
     LLVMSetInitializer(vtable->llvmvtables, vtablelist);
 
     // Build the virtual reference type for this vtable. It is a fat pointer:

--- a/test/cases/closure/cases.toml
+++ b/test/cases/closure/cases.toml
@@ -39,6 +39,17 @@ category = "run"
 description = "Anonymous functions bound, typed, passed to a parameter and called"
 tags = ["parse", "nameres", "typecheck", "flow", "genllvm", "runtime"]
 
+# An anonymous function is lifted to module scope, where it needs a name -- for
+# a COMDAT to be named after, and because the name LLVM's mangler invents for an
+# unnamed symbol ('__unnamed_1') is one every other object file would invent too.
+# Internal linkage settles the collision and lets the optimizer delete the ones
+# nothing calls, which is why only some of this file's literals are left here.
+[[scenario.closure-success.check]]
+name = "anonymous-functions-are-named-and-private"
+target = "llvmir"
+contains = ["define internal i32 @anon"]
+excludes = ["define i32 @0(", "define i32 @1("]
+
 [scenario.closure-capture]
 category = "compile"
 description = "An anonymous function reading a local of the function enclosing it"

--- a/test/cases/core/cases.toml
+++ b/test/cases/core/cases.toml
@@ -38,6 +38,13 @@ options = []
 name = "debug"
 options = ["--debug"]
 
+# A global variable is discardable on the same terms as a function, and for the
+# same reason.
+[[scenario.core-success.check]]
+name = "global-variables-are-individually-discardable"
+target = "llvmir"
+contains = ["$counter = comdat nodeduplicate", "@counter = global i32 0, comdat"]
+
 [scenario.core-overload]
 category = "run"
 description = "Which candidate of an overload set a call selects"
@@ -65,6 +72,24 @@ excludes = ["@scale(", "@join(", "@step(", "@emit("]
 name = "private-candidate-keeps-its-symbol"
 target = "llvmir"
 contains = ["define hidden i64 @_emitUnsigned"]
+
+# Each function leads a COMDAT named for itself. A COFF section is otherwise
+# all-or-nothing, so without this every function an object file defines ships in
+# the executable whether the program can reach it or not; with it the linker
+# discards the unreachable ones. A private function gets one too -- hidden
+# visibility does not stop a symbol leading a COMDAT.
+#
+# 'nodeduplicate' is the selection kind that keeps a duplicate definition a link
+# error. Only what must merge asks to merge; generic-success pins the other side.
+[[scenario.core-overload.check]]
+name = "functions-are-individually-discardable"
+target = "llvmir"
+contains = [
+  "$scaleInt = comdat nodeduplicate",
+  "define i64 @scaleInt(i64 %0) comdat {",
+  "$_emitUnsigned = comdat nodeduplicate",
+  "define hidden i64 @_emitUnsigned(i64 %0) comdat {",
+]
 
 # -------- warnings --------
 

--- a/test/cases/core/cases.toml
+++ b/test/cases/core/cases.toml
@@ -39,11 +39,18 @@ name = "debug"
 options = ["--debug"]
 
 # A global variable is discardable on the same terms as a function, and for the
-# same reason.
+# same reason. So is a string literal, which is private to its object file and
+# so cannot collide with anything, but would otherwise sit in a shared section
+# and outlive the dead function that was its only mention.
 [[scenario.core-success.check]]
 name = "global-variables-are-individually-discardable"
 target = "llvmir"
-contains = ["$counter = comdat nodeduplicate", "@counter = global i32 0, comdat"]
+contains = [
+  "$counter = comdat nodeduplicate",
+  "@counter = global i32 0, comdat",
+  "$string = comdat nodeduplicate",
+  '@string = internal constant [3 x i8] c" = ", comdat',
+]
 
 [scenario.core-overload]
 category = "run"

--- a/test/cases/generic/cases.toml
+++ b/test/cases/generic/cases.toml
@@ -35,6 +35,19 @@ tags = ["parse", "nameres", "typecheck", "genllvm", "runtime"]
 # One 'define' per distinct set of type arguments, under a name carrying them,
 # and never one for the generic itself. This is the only place instantiation is
 # visible: which instance ran is not something the program can print.
+# An instance is the one symbol several object files may each define, so it is
+# the one that asks the linker to keep a single copy -- 'comdat any', matching
+# the linkonce linkage. An ordinary function in the same file asks the opposite,
+# so that a genuine duplicate definition stays a link error.
+[[scenario.generic-success.check]]
+name = "only-instances-ask-the-linker-to-merge"
+target = "llvmir"
+contains = [
+  '$"max:i64:i64" = comdat any',
+  'define linkonce i64 @"max:i64:i64"(i64 %0, i64 %1) comdat {',
+  "$inferredTypeArgument = comdat nodeduplicate",
+]
+
 [[scenario.generic-success.check]]
 name = "one-instance-per-type-argument"
 target = "llvmir"

--- a/test/cases/module/cases.toml
+++ b/test/cases/module/cases.toml
@@ -67,6 +67,18 @@ name = "no-symbol-for-imported-overload-name"
 target = "llvmir"
 excludes = ["@modulesub_scale(", "@modulesub__hidden", "_hiddenOne"]
 
+# The other half of the COMDAT rule core-overload states: only a definition may
+# lead one. An imported module's functions have bodies in the IR, but this
+# object file merely declares them, so they get none.
+[[scenario.module-imports.check]]
+name = "imported-declarations-carry-no-comdat"
+target = "llvmir"
+excludes = [
+  "@modulesub_scaleInt(i64) comdat",
+  "@modulesub__scaleFloat(double) comdat",
+  "@modulesub_plain(i64) comdat",
+]
+
 [scenario.module-qualified]
 category = "compile"
 description = "An import without '::*', whose members are reached by qualifying them"

--- a/test/cases/trait/cases.toml
+++ b/test/cases/trait/cases.toml
@@ -138,6 +138,19 @@ tags = ["parse", "nameres", "typecheck", "flow", "genllvm", "runtime"]
 # slot holding a null function pointer is what the IR shows and what the printed
 # numbers cannot, and a bitcast of the real method is the proof the slot was
 # filled from a symbol rather than left empty.
+# A vtable is a definition several object files may each supply, so it merges
+# like a generic instance rather than colliding. It needs a COMDAT for a second
+# reason too: it names every method in its slots, so a vtable the linker cannot
+# discard keeps all of them in the image whether or not anything dispatches.
+[[scenario.trait-variants.check]]
+name = "vtables-are-discardable-and-mergeable"
+target = "llvmir"
+contains = [
+  '$"Variant1->Extense:Vtable" = comdat any',
+  '$"Rect->Shape:Vtable" = comdat any',
+  "$vtable-list = comdat any",
+]
+
 [[scenario.trait-variants.check]]
 name = "late-declared-structural-conformer-fills-its-vtable-slot"
 target = "llvmir"

--- a/workitems/packages-and-separate-compilation.md
+++ b/workitems/packages-and-separate-compilation.md
@@ -216,6 +216,29 @@ A symbol's spelling is a function of the package, never of which module was
   purely cross-package.
 - Handle `genname` correctly regardless of aliasing and cross-package reference —
   the same requirement [[ir-refactor|IR refactor]] item 2.1 states for `genericdef`.
+- **Instantiating an imported module's generic emits an invalid declaration.**
+  Measured on two files, an importer calling `pick[i64]` from an imported
+  module: `declare linkonce i64 @"gsub_pick:i64:i64"`, which fails `--verify`
+  with "Global is external, but doesn't have external or weak linkage". The
+  instance hangs off the *imported* module's generic node, so the symbol pass
+  names it and the implementation pass, which visits only modules flagged for
+  generation, never gives it a body. Nothing in the corpus catches it: no
+  scenario imports a module containing a generic, because the `generic` group
+  imports only `stdio` and `stdio` is carved out into being generated. The fix is
+  the exception `design/nodes/module.md` states under "Composing packages" — the
+  importer defines the instance — and it is narrower than what got stage 1
+  dropped, since generating an imported module's instances is not generating its
+  modules. The scenario belongs with it, in the `module` group.
+- **Fold the linkage and COMDAT decision into one call.** Generation sets
+  linkage in six places and attaches a COMDAT in five, and the two are not
+  paired: a generic instance takes its linkage in the symbol pass and its COMDAT
+  in the implementation pass, so the pair can disagree with nothing to catch it.
+  A call taking the concept — local, unique to this object, merged across
+  objects — would derive both, per target, the way the COMDAT already derives
+  from linkage. It waits on this stage twice over: "what a package exports"
+  above adds the rows the concept does not have yet, and moving the generic
+  case's linkage out of the symbol pass is the same edit as the bug above.
+  `design/phases/generation.md` section 2 carries today's mapping.
 
 **This is the stage that makes `import` mean something.** Generation already
 emits an imported module's public names as declarations and its private ones not

--- a/workitems/packages-and-separate-compilation.md
+++ b/workitems/packages-and-separate-compilation.md
@@ -111,26 +111,65 @@ definitions: compiled on its own a module emits `@scaleInt`, unprefixed, while a
 importer declares `@modulesub_scaleInt`. That is the whole of the code-generation
 gap, and `stdio`'s filename `strcmp` exists to carve one module out of it.
 
-### 2. Function-per-section and COMDAT
+### 2. Per-symbol COMDAT — done
 
-So the linker's inclusion granularity is the function rather than the object
-file.
+So the linker's inclusion granularity is the symbol rather than the object file.
 
-- Emit a section and a COMDAT per function in `genlGloFnName`. `LLVMSetSection`
-  and the `Comdat.h` API are both in LLVM 13's C API; `LLVMCreateTargetMachine`
-  takes no `TargetOptions`, so there is no `FunctionSections` switch to flip.
-  The COFF path needs a spike confirming the hand-rolled COMDAT matches `/Gy`.
-- Teach congo `--gc-sections` on ELF and wasm, `/OPT:REF` on COFF — which is off
-  by default whenever `/DEBUG` is on.
-- **Measure dependency fan-out.** Section GC decides what reaches the binary, not
-  what must resolve at link time: archive extraction precedes it, so calling one
-  function from a package pulls its whole object and every undefined symbol in it
-  enters resolution. Whether that hard-errors for a symbol only unreachable code
-  references depends on linker and version. It needs two packages to measure, so
-  it waits on stage 3 giving a separately built module resolvable symbols.
+**Every generated definition now leads a COMDAT named for itself**, function and
+global variable alike, with the selection kind following the linkage: `any` for
+the generic instantiations that must merge, `nodeduplicate` for everything else
+so a duplicate definition stays a link error.
+`design/phases/generation.md` section 2 carries the rule, its one exception, and
+the object formats that cannot take it. No separate section call is needed after
+all: on COFF a COMDAT already puts its symbol in a section of its own, so
+`LLVMSetSection` and the missing `FunctionSections` switch are both moot.
 
-**Lands with:** `llvmir` checks on section and COMDAT emission, and the fan-out
-measurement recorded in `design/nodes/module.md`.
+Measured on COFF, linking with `/OPT:REF` a program that imports `stdio` and
+prints one integer: all five of `IOStream`'s append methods reached the
+executable before, none do now, and `.text` fell from 4028 to 3740 bytes. Two
+uncalled user-written functions went the same way, and an unused global variable
+with them. A used function too large to inline still ships, and the programs
+still print what they printed. Measured separately, linking two objects that
+each define the same symbol: an instantiation of `max[i64]` merges silently, and
+an ordinary function is `LNK2005: already defined`.
+
+Three of the stage's uncertainties closed on the way.
+
+- **Hidden visibility does not stop a symbol leading a COMDAT**, so a private
+  function strips like any other. That was the one risk that could have forced a
+  different approach.
+- **The anonymous `fn` literal** — no name, so nothing for a COMDAT to be named
+  after, and `__unnamed_1` to collide over — is settled here rather than deferred
+  to stage 3. It gets a generated name and internal linkage, which also lets the
+  inliner delete the unused ones outright.
+- **Dependency fan-out is dropped rather than deferred.** Archive extraction
+  precedes section GC, so pulling one function from a package pulls its whole
+  object and every undefined symbol in it must resolve. That is what every
+  toolchain does, it is invisible under a package manager, and the answer for an
+  optional dependency is conditional compilation. It does not bear on the
+  one-object-file-per-package decision.
+
+Still owed:
+
+- **Teach congo the flags:** `--gc-sections` on ELF and wasm, `/OPT:REF` on COFF
+  — which is off by default whenever `/DEBUG` is on — and `-dead_strip` on
+  Mach-O, which is how that format does the same job without COMDATs.
+- **The suite has no cross-target coverage**, and this stage is the argument for
+  it: Mach-O rejects COMDATs outright and WebAssembly rejects every selection
+  kind but `any`, so the first working version of this change hard-errored on
+  both and every scenario still passed. Compiling one source per object format is
+  a few seconds of suite time. Where it belongs is a suite-shape question —
+  `driver` is the only group that follows no manual chapter, but its own note
+  says a driver scenario has no Cone source.
+- **ELF is compiled but not linked.** `nodeduplicate` lowers there without
+  complaint; that a duplicate still errors and an unreachable symbol still goes
+  is measured on COFF only.
+
+**Landed with:** `functions-are-individually-discardable` and
+`global-variables-are-individually-discardable` in `test/cases/core`,
+`only-instances-ask-the-linker-to-merge` in `test/cases/generic`,
+`anonymous-functions-are-named-and-private` in `test/cases/closure`, and
+`imported-declarations-carry-no-comdat` in `test/cases/module`.
 
 ### 3. Package-rooted symbol identity
 

--- a/workitems/packages-and-separate-compilation.md
+++ b/workitems/packages-and-separate-compilation.md
@@ -115,10 +115,11 @@ gap, and `stdio`'s filename `strcmp` exists to carve one module out of it.
 
 So the linker's inclusion granularity is the symbol rather than the object file.
 
-**Every generated definition now leads a COMDAT named for itself**, function and
-global variable alike, with the selection kind following the linkage: `any` for
-the generic instantiations that must merge, `nodeduplicate` for everything else
-so a duplicate definition stays a link error.
+**Every generated definition now leads a COMDAT named for itself** — function,
+global variable, vtable and string literal — with the selection kind following
+the linkage: `any` for the generic instantiations and vtables that must merge,
+`nodeduplicate` for everything else so a duplicate definition stays a link
+error.
 `design/phases/generation.md` section 2 carries the rule, its one exception, and
 the object formats that cannot take it. No separate section call is needed after
 all: on COFF a COMDAT already puts its symbol in a section of its own, so
@@ -142,6 +143,15 @@ Three of the stage's uncertainties closed on the way.
   after, and `__unnamed_1` to collide over — is settled here rather than deferred
   to stage 3. It gets a generated name and internal linkage, which also lets the
   inliner delete the unused ones outright.
+- **Not every generated global went through the new code**, and a symbol that
+  misses it keeps alive everything it names. A vtable names every method in its
+  slots, so before this a struct coerced to `&<Trait` kept all of them in the
+  image whether or not anything dispatched: measured, a program that takes one
+  `&<Shape` and never calls through it shipped the method, the vtable and the
+  vtable list, and now ships none of the three, `.text` falling from 4092 to
+  3756 bytes. A string literal only a dead function mentioned survived the same
+  way. Both are routed through it now; `design/phases/generation.md` section 2
+  lists the call sites, because the next kind of generated global has to add one.
 - **Dependency fan-out is dropped rather than deferred.** Archive extraction
   precedes section GC, so pulling one function from a package pulls its whole
   object and every undefined symbol in it must resolve. That is what every
@@ -168,6 +178,7 @@ Still owed:
 **Landed with:** `functions-are-individually-discardable` and
 `global-variables-are-individually-discardable` in `test/cases/core`,
 `only-instances-ask-the-linker-to-merge` in `test/cases/generic`,
+`vtables-are-discardable-and-mergeable` in `test/cases/trait`,
 `anonymous-functions-are-named-and-private` in `test/cases/closure`, and
 `imported-declarations-carry-no-comdat` in `test/cases/module`.
 


### PR DESCRIPTION
Stage 2 of `workitems/packages-and-separate-compilation.md`: make the linker's
inclusion granularity the symbol rather than the object file.

## The problem

A section is all-or-nothing, so every function an object file defined shipped in
the executable whether or not the program could reach it. A program that imports
`stdio` and prints one integer carried all five of `IOStream`'s stream-append
methods, and any function the user wrote and never called.

## What changed

Every generated definition — function, global variable, vtable, vtable list and
string literal — now leads a COMDAT named for its own symbol, so the linker can
discard the unreachable ones and, transitively, whatever only they referenced.

Two questions have to be answered per symbol, and they are not independent. The
caller picks the linkage; `genlComdat` derives the rest, so a new kind of symbol
cannot end up with a selection kind that contradicts its linkage:

| What the symbol is | Linkage | Derived |
| --- | --- | --- |
| a definition only this object can supply | external | `nodeduplicate` — a duplicate stays a link error |
| a definition several objects may each supply — a generic instance, a vtable | `linkonce` | `any` — the linker keeps one |
| a definition nothing outside can name — an anonymous `fn`, a string literal | `internal` | `nodeduplicate`; it cannot collide in any case |
| a declaration | external | nothing: only a definition may lead a COMDAT |

`design/phases/generation.md` section 2 carries this, the call sites, and the
note that a new kind of generated global has to add another one.

## Measured

Linking with `/OPT:REF` against `conestd`, master's `conec` versus this one:

| program | `.text` before | after |
| --- | --- | --- |
| prints one integer | 4028 | 3740 |
| plus two functions nobody calls | 4060 | 3740 |
| plus a used recursive function | 4124 | 3788 |
| takes one `&<Shape`, never dispatches | 4092 | 3756 |

Stream-append methods reaching the image: 5 of 5 before, 0 of 5 after — zero
rather than one because the optimizer inlines the one-line method into `main`,
so all five were already dead and only the missing COMDATs kept them. Every
program still prints what it printed.

Duplicate handling, linking two objects that each define the same symbol:

```
two objects that both instantiate max[i64]  ->  linked with no complaint
an ordinary function defined twice          ->  LNK2005: fromA already defined
```

## Three things worth a reviewer's attention

**Vtables were the expensive one.** A vtable names every method in its slots, so
before this a struct coerced to `&<Trait` kept all of them in the image whether
or not anything ever dispatched. That is the fourth row of the table above.

**Anonymous `fn` literals were public and nameless.** LLVM's mangler calls an
unnamed symbol `__unnamed_1`, which every other object file would also call
`__unnamed_1`; one closure scenario emitted 27 of them. They now get a generated
name and internal linkage, which additionally lets the inliner delete the ones
nothing calls.

**Not every object format takes COMDATs.** Mach-O has none and needs none — its
assembler emits `.subsections_via_symbols` — and WebAssembly lowers only `any`.
Both are hard errors inside LLVM's backend, so `genSetup` asks the triple.

## Testing

Full suite green: 128 scenarios, 129 runs, 1 expected failure. Six new `llvmir`
checks across `core`, `generic`, `trait`, `closure` and `module`, each verified
to fail against an unpatched compiler. All four target formats compile.

**One gap this change argues for and does not fill.** The suite has no
cross-target coverage, so the first working version of this hard-errored on
Mach-O and WebAssembly with every scenario still passing. Compiling one source
per object format is a few seconds of suite time, but where it belongs is a
suite-shape question — `driver` is the only group following no manual chapter,
and its own note says a driver scenario has no Cone source. Recorded as owed.

## Also recorded

`design/nodes/module.md` stated that an import's declarations are "never defined
by this compile" while explaining six lines later that an importer needs the
bodies of anything that monomorphizes or expands at the use site. The rule now
carries that exception, bounded to what the imported package could not have
emitted itself.

Stage 3 gains two entries found on the way: instantiating an imported module's
generic emits an invalid `declare linkonce` (pre-existing — master fails the same
two-file input identically, and no scenario catches it because none imports a
module holding a generic), and folding the linkage and COMDAT decision into one
concept-taking call, which waits on stage 3 deciding what a package exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
